### PR TITLE
Improved tracking of whether a drag is active in the editor

### DIFF
--- a/src/component/handlers/drag/DraftEditorDragHandler.ts
+++ b/src/component/handlers/drag/DraftEditorDragHandler.ts
@@ -88,7 +88,6 @@ const DraftEditorDragHandler = {
     );
 
     e.preventDefault();
-    editor._dragCount = 0;
     editor.exitCurrentMode();
 
     if (dropSelection == null) {


### PR DESCRIPTION
The previous approach failed in cases where elements were added/removed from draft editor during a drag (i.e., the `onDragLeave` handler wasn't fired in cases where a previously-entered element was removed from the DOM). This happens because we dynamically update the draft editor state during the drag, which changes the DOM structure. This would lead to Draft.js getting stuck in the `"drag"` mode until something else forced it out of that mode (e.g., a future "drop.")

This new approach tracks the event targets of the drag enter/leave events. If any drag target is no longer in the document, we do not count it when determining if there is any active entered drag.

Repro bug: https://codepen.io/steverubin/pen/NWxJEzr