### PR TITLE
Fix error thrown when making selection across 2 or more draft.js `Editor` components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@descript/draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.11.6-descript.4",
+  "version": "0.11.6-descript.5",
   "keywords": [
     "draftjs",
     "editor",

--- a/src/component/selection/getUpdatedSelectionState.ts
+++ b/src/component/selection/getUpdatedSelectionState.ts
@@ -7,7 +7,7 @@
  * @format
  * @emails oncall+draft_js
  */
-import {EditorState, getBlockTree} from '../../model/immutable/EditorState';
+import {EditorState, getBlockTreeMaybe} from '../../model/immutable/EditorState';
 import {SelectionState} from '../../model/immutable/SelectionState';
 import {nullthrows} from '../../fbjs/nullthrows';
 import DraftOffsetKey from './DraftOffsetKey';
@@ -32,7 +32,7 @@ export default function getUpdatedSelectionState(
 
   const anchorPath = DraftOffsetKey.decode(anchorKey);
   const anchorBlockKey = anchorPath.blockKey;
-  const anchorLeafBlockTree = getBlockTree(editorState, anchorBlockKey);
+  const anchorLeafBlockTree = getBlockTreeMaybe(editorState, anchorBlockKey);
   const anchorLeaf =
     anchorLeafBlockTree?.[anchorPath.decoratorKey]?.leaves?.[
       anchorPath.leafKey
@@ -40,7 +40,7 @@ export default function getUpdatedSelectionState(
 
   const focusPath = DraftOffsetKey.decode(focusKey);
   const focusBlockKey = focusPath.blockKey;
-  const focusLeafBlockTree = getBlockTree(editorState, focusBlockKey);
+  const focusLeafBlockTree = getBlockTreeMaybe(editorState, focusBlockKey);
   const focusLeaf =
     focusLeafBlockTree?.[focusPath.decoratorKey]?.leaves?.[focusPath.leafKey];
 

--- a/src/model/immutable/EditorState.ts
+++ b/src/model/immutable/EditorState.ts
@@ -209,6 +209,13 @@ export function getBlockTree(
   return res;
 }
 
+export function getBlockTreeMaybe(
+  {treeMap}: EditorState,
+  blockKey: string,
+): readonly DecoratorRange[] | undefined {
+  return treeMap.get(blockKey);
+}
+
 export function isSelectionAtStartOfContent({
   currentContent,
   selection,
@@ -389,7 +396,6 @@ function push<T>(arr: readonly T[], item: T): readonly T[] {
   return arr.concat([item]);
 }
 
-
 /**
  * Make the top ContentState in the undo stack the new current content and
  * push the current content onto the redo stack.
@@ -453,7 +459,7 @@ export function redo(editorState: EditorState): EditorState {
     lastChangeType: 'redo',
     nativelyRenderedContent: null,
     selection: newCurrentContent.selectionAfter,
-  })
+  });
 }
 
 /**


### PR DESCRIPTION
This is a regression from the pojo port. In most calls to `getBlockTree` we are assuming that the specified `blockKey` exists in the tree. However, in `getUpdatedSelectionState`, this is not the case. See: 

https://github.com/facebook/draft-js/blob/0585b68fed5e1d732692f24989fa0fb1dd54c6f2/src/component/selection/getUpdatedSelectionState.js#L60:L67

To reproduce: 
- Make a page with 2 draft.js Editor components
- Click and drag to make a selection in one
- Continue dragging into the other component. Release.
- An error is thrown