### PR TITLE
Block inline styles + other optimizations

### DIFF
--- a/docs/APIReference-Editor.md
+++ b/docs/APIReference-Editor.md
@@ -91,10 +91,10 @@ Provide a map of block rendering configurations. Each block type maps to element
 ### `blockStyleFn`
 
 ```js
-blockStyleFn?: (block: ContentBlock) => string
+blockStyleFn?: (block: ContentBlock) => string | CSSProperties | undefined
 ```
 
-Optionally set a function to define class names to apply to the given block when it is rendered. See [Advanced Topics: Block Styling](/docs/advanced-topics-block-styling) for details on usage.
+Optionally set a function to define class names or inline styles to apply to the given block when it is rendered. See [Advanced Topics: Block Styling](/docs/advanced-topics-block-styling) for details on usage.
 
 ### customStyleMap
 

--- a/docs/Advanced-Topics-Block-Styling.md
+++ b/docs/Advanced-Topics-Block-Styling.md
@@ -8,7 +8,7 @@ of basic configuration required to get engineers up and running with custom
 editors.
 
 By defining a `blockStyleFn` prop function for an `Editor`, it is possible
-to specify classes that should be applied to blocks at render time.
+to specify classes and inline styles that should be applied to blocks at render time.
 
 ## DraftStyleDefault.css
 
@@ -22,15 +22,20 @@ styles.
 
 ## blockStyleFn
 
-The `blockStyleFn` prop on `Editor` allows you to define CSS classes to
-style blocks at render time. For instance, you may wish to style `'blockquote'`
-type blocks with fancy italic text.
+The `blockStyleFn` prop on `Editor` allows you to define CSS classes and inline
+styles to style blocks at render time. For instance, you may wish to style
+`'blockquote'` type blocks with fancy italic text.
 
 ```js
 function myBlockStyleFn(contentBlock) {
   const type = contentBlock.getType();
   if (type === 'blockquote') {
     return 'superFancyBlockquote';
+  } else if (type === 'section') {
+    return {
+      color: 'blue',
+      margin: '5px',
+    };
   }
 }
 

--- a/src/component/contents/DraftEditorBlock.react.tsx
+++ b/src/component/contents/DraftEditorBlock.react.tsx
@@ -276,6 +276,8 @@ export default class DraftEditorBlock extends React.Component<Props> {
       const leaves = leavesForLeafSet.map((leaf, jj) => {
         const offsetKey = DraftOffsetKey.encode(blockKey, ii, jj);
         const {start, end} = leaf;
+        // use the start position in the block to determine when to update rather than rebuild an element
+        // (switching this from using the leaf index `ii` because we frequently add/remove ephemeral decorators)
         const key = `${blockKey}-${start}`;
         return (
           <DraftEditorLeaf

--- a/src/component/contents/DraftEditorBlock.react.tsx
+++ b/src/component/contents/DraftEditorBlock.react.tsx
@@ -276,7 +276,7 @@ export default class DraftEditorBlock extends React.Component<Props> {
       const leaves = leavesForLeafSet.map((leaf, jj) => {
         const offsetKey = DraftOffsetKey.encode(blockKey, ii, jj);
         const {start, end} = leaf;
-        const key = `${blockKey}-${start}-${end}`;
+        const key = `${blockKey}-${start}`;
         return (
           <DraftEditorLeaf
             key={key}
@@ -316,7 +316,7 @@ export default class DraftEditorBlock extends React.Component<Props> {
       const end = leavesForLeafSet[leavesForLeafSet.length - 1].end;
       const decoratedText = text.slice(start, end);
       const entityKey = getEntityAt(block, leafSet.start);
-      const key = `${blockKey}-${start}-${end}`;
+      const key = `${blockKey}-${start}`;
 
       // Resetting dir to the same value on a child node makes Chrome/Firefox
       // confused on cursor movement. See http://jsfiddle.net/d157kLck/3/

--- a/src/component/contents/DraftEditorContents-core.react.tsx
+++ b/src/component/contents/DraftEditorContents-core.react.tsx
@@ -12,7 +12,7 @@ import {BidiDirection} from 'fbjs/lib/UnicodeBidiDirection';
 import {DraftBlockRenderMap} from '../../model/immutable/DraftBlockRenderMap';
 import {DraftInlineStyle} from '../../model/immutable/DraftInlineStyle';
 import {EditorState, getBlockTree} from '../../model/immutable/EditorState';
-import React, {ReactNode} from 'react';
+import React, {CSSProperties, ReactNode} from 'react';
 import cx from 'fbjs/lib/cx';
 import joinClasses from 'fbjs/lib/joinClasses';
 import {nullthrows} from '../../fbjs/nullthrows';
@@ -23,7 +23,7 @@ import {BlockNode} from '../../model/immutable/BlockNode';
 type Props = {
   blockRenderMap: DraftBlockRenderMap;
   blockRendererFn: (block: BlockNode) => Record<string, any> | null;
-  blockStyleFn?: (block: BlockNode) => string;
+  blockStyleFn?: (block: BlockNode) => string | CSSProperties | undefined;
   customStyleFn?: (
     style: DraftInlineStyle,
     block: BlockNode,
@@ -205,8 +205,16 @@ export default class DraftEditorContents extends React.Component<Props> {
 
       const depth = block.depth;
       let className = '';
+      let inlineStyle: CSSProperties | undefined;
       if (blockStyleFn) {
-        className = blockStyleFn(block);
+        const classNameOrStyle = blockStyleFn(block);
+        if (classNameOrStyle !== undefined) {
+          if (typeof classNameOrStyle === 'string') {
+            className = classNameOrStyle;
+          } else {
+            inlineStyle = classNameOrStyle;
+          }
+        }
       }
 
       // List items are special snowflakes, since we handle nesting and
@@ -230,6 +238,7 @@ export default class DraftEditorContents extends React.Component<Props> {
         'data-offset-key': offsetKey,
         id: `block-${key}`,
         key,
+        style: inlineStyle,
       };
       if (customEditable !== undefined) {
         childProps = {

--- a/src/component/contents/DraftEditorContents-core.react.tsx
+++ b/src/component/contents/DraftEditorContents-core.react.tsx
@@ -208,12 +208,10 @@ export default class DraftEditorContents extends React.Component<Props> {
       let inlineStyle: CSSProperties | undefined;
       if (blockStyleFn) {
         const classNameOrStyle = blockStyleFn(block);
-        if (classNameOrStyle !== undefined) {
-          if (typeof classNameOrStyle === 'string') {
-            className = classNameOrStyle;
-          } else {
-            inlineStyle = classNameOrStyle;
-          }
+        if (typeof classNameOrStyle === 'string') {
+          className = classNameOrStyle;
+        } else {
+          inlineStyle = classNameOrStyle;
         }
       }
 


### PR DESCRIPTION
- Change React keys for block leaves to not include the leaf end position. This will lead to more cases where we update a component rather than regenerating a new one.
- DraftEditor `blockStyleFn` can now return inline styles, not just class names.
