### PR TITLE
Preserve selection in simple case

### DIFF
--- a/src/component/selection/setDraftEditorSelection.ts
+++ b/src/component/selection/setDraftEditorSelection.ts
@@ -149,6 +149,16 @@ export function setDraftEditorSelection(
   // If the selection is entirely bound within this node, set the selection
   // and be done.
   if (hasAnchor && hasFocus) {
+    if (
+      selection.anchorNode === node &&
+      selection.focusNode === node &&
+      selection.anchorOffset === anchorOffset - nodeStart &&
+      selection.focusOffset === focusOffset - nodeStart
+    ) {
+      // the selection is already correct
+      return;
+    }
+
     selection.removeAllRanges();
     addPointToSelection(
       selection,


### PR DESCRIPTION
In the simplest case, preserve the existing DOM selection. There are probably more optimizations to do here, but this is an easy one.