### PR TITLE
Force render blocks when blockStyleFn changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@descript/draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.11.6-descript.8",
+  "version": "0.11.6-descript.9",
   "keywords": [
     "draftjs",
     "editor",

--- a/src/component/contents/DraftEditorContents-core.react.tsx
+++ b/src/component/contents/DraftEditorContents-core.react.tsx
@@ -95,6 +95,10 @@ export default class DraftEditorContents extends React.Component<Props> {
       return true;
     }
 
+    if (this.props.blockStyleFn !== nextProps.blockStyleFn) {
+      return true;
+    }
+
     const nextNativeContent = nextEditorState.nativelyRenderedContent;
 
     const wasComposing = prevEditorState.inCompositionMode;


### PR DESCRIPTION
If the `blockStyleFn` changes (i.e., in our use case, if deps of the `useCallback` that creates that function change), re-render the DraftEditorContents.