### PR TITLE
Bulk entity application

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+      - run: yarn
       - run: yarn lint
       - run: yarn build
       - run: yarn test-ci

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,21 @@
+name: Node CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: yarn lint
+      - run: yarn build
+      - run: yarn test-ci

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@descript/draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.11.6-descript.9",
+  "version": "0.11.6-descript.10",
   "keywords": [
     "draftjs",
     "editor",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "gulp",
     "dev": "gulp dev",
     "postbuild": "node node_modules/fbjs-scripts/node/check-lib-requires.js lib",
-    "lint": "eslint .",
+    "lint": "eslint src/.",
     "lint-docs": "alex . && yarn format-docs:diff",
     "format": "eslint . --fix",
     "format-docs": "prettier --config prettier.config.js --write \"docs/**/*.md\"",

--- a/src/component/selection/getUpdatedSelectionState.ts
+++ b/src/component/selection/getUpdatedSelectionState.ts
@@ -7,7 +7,10 @@
  * @format
  * @emails oncall+draft_js
  */
-import {EditorState, getBlockTreeMaybe} from '../../model/immutable/EditorState';
+import {
+  EditorState,
+  getBlockTreeMaybe,
+} from '../../model/immutable/EditorState';
 import {SelectionState} from '../../model/immutable/SelectionState';
 import {nullthrows} from '../../fbjs/nullthrows';
 import DraftOffsetKey from './DraftOffsetKey';

--- a/src/model/immutable/BlockMap.ts
+++ b/src/model/immutable/BlockMap.ts
@@ -57,7 +57,7 @@ export type BlockMapIndex = Record<string, string | null>;
  * Creates an object where obj[blockKey] is the next block key.
  * If `blockKey` is the final block of the blockMap, it is instead `null`
  */
-export function makeBlockMapIndex(
+export function makeNextBlockKeyIndex(
   blockMap: BlockMap,
 ): Record<string, string | null> {
   const indexes: BlockMapIndex = {};

--- a/src/model/immutable/BlockMap.ts
+++ b/src/model/immutable/BlockMap.ts
@@ -51,3 +51,25 @@ export function mergeMapUpdates<T>(
   );
   return didChange ? result : originalMap;
 }
+
+export type BlockMapIndex = Record<string, string | null>;
+/**
+ * Creates an object where obj[blockKey] is the next block key.
+ * If `blockKey` is the final block of the blockMap, it is instead `null`
+ */
+export function makeBlockMapIndex(
+  blockMap: BlockMap,
+): Record<string, string | null> {
+  const indexes: BlockMapIndex = {};
+  let prevKey: string | undefined;
+  for (const blockKey of blockMap.keys()) {
+    if (prevKey !== undefined) {
+      indexes[prevKey] = blockKey;
+    }
+    prevKey = blockKey;
+  }
+  if (prevKey) {
+    indexes[prevKey] = null;
+  }
+  return indexes;
+}

--- a/src/model/modifier/DraftModifier.ts
+++ b/src/model/modifier/DraftModifier.ts
@@ -33,7 +33,9 @@ import getCharacterRemovalRange from './getCharacterRemovalRange';
 import DraftEntity from '../entity/DraftEntity';
 import splitBlockInContentState from '../transaction/splitBlockInContentState';
 import ContentStateInlineStyle from '../transaction/ContentStateInlineStyle';
-import applyEntityToContentState from '../transaction/applyEntityToContentState';
+import applyEntityToContentState, {
+  applyEntitiesToContentState,
+} from '../transaction/applyEntityToContentState';
 
 /**
  * `DraftModifier` provides a set of convenience methods that apply
@@ -258,6 +260,13 @@ const DraftModifier = {
       selectionState,
       entityKey,
     );
+  },
+
+  applyEntities: function(
+    contentState: ContentState,
+    entities: Iterable<[SelectionState, string | null]>,
+  ): ContentState {
+    return applyEntitiesToContentState(contentState, entities);
   },
 };
 

--- a/src/model/transaction/__tests__/__snapshots__/applyEntityToContentBlock-test.ts.snap
+++ b/src/model/transaction/__tests__/__snapshots__/applyEntityToContentBlock-test.ts.snap
@@ -64,6 +64,56 @@ Object {
 }
 `;
 
+exports[`must apply to mutable character list 1`] = `
+Array [
+  Object {
+    "entity": null,
+    "style": Set {},
+  },
+  Object {
+    "entity": "x",
+    "style": Set {},
+  },
+  Object {
+    "entity": "x",
+    "style": Set {},
+  },
+  Object {
+    "entity": "x",
+    "style": Set {},
+  },
+  Object {
+    "entity": null,
+    "style": Set {},
+  },
+]
+`;
+
+exports[`must apply to mutable character list 2`] = `
+Array [
+  Object {
+    "entity": null,
+    "style": Set {},
+  },
+  Object {
+    "entity": "x",
+    "style": Set {},
+  },
+  Object {
+    "entity": "y",
+    "style": Set {},
+  },
+  Object {
+    "entity": "x",
+    "style": Set {},
+  },
+  Object {
+    "entity": null,
+    "style": Set {},
+  },
+]
+`;
+
 exports[`must apply to the entire text 1`] = `
 Object {
   "characterList": Array [

--- a/src/model/transaction/__tests__/__snapshots__/applyEntityToContentState-test.ts.snap
+++ b/src/model/transaction/__tests__/__snapshots__/applyEntityToContentState-test.ts.snap
@@ -330,6 +330,214 @@ Object {
 }
 `;
 
+exports[`must apply multiple entities across multiple blocks 1`] = `
+Object {
+  "characterList": Array [
+    Object {
+      "entity": "x",
+      "style": Set {},
+    },
+    Object {
+      "entity": "x",
+      "style": Set {},
+    },
+    Object {
+      "entity": "x",
+      "style": Set {},
+    },
+    Object {
+      "entity": "x",
+      "style": Set {},
+    },
+    Object {
+      "entity": "x",
+      "style": Set {},
+    },
+  ],
+  "data": Object {},
+  "depth": 0,
+  "key": "a",
+  "text": "Alpha",
+  "type": "unstyled",
+}
+`;
+
+exports[`must apply multiple entities across multiple blocks 2`] = `
+Object {
+  "characterList": Array [
+    Object {
+      "entity": "x",
+      "style": Set {
+        "BOLD",
+      },
+    },
+    Object {
+      "entity": "x",
+      "style": Set {
+        "BOLD",
+      },
+    },
+    Object {
+      "entity": "x",
+      "style": Set {
+        "BOLD",
+      },
+    },
+    Object {
+      "entity": "x",
+      "style": Set {
+        "BOLD",
+      },
+    },
+    Object {
+      "entity": "y",
+      "style": Set {
+        "BOLD",
+      },
+    },
+  ],
+  "data": Object {},
+  "depth": 0,
+  "key": "b",
+  "text": "Bravo",
+  "type": "unordered-list-item",
+}
+`;
+
+exports[`must apply multiple entities across multiple blocks 3`] = `
+Object {
+  "characterList": Array [
+    Object {
+      "entity": "y",
+      "style": Set {},
+    },
+    Object {
+      "entity": null,
+      "style": Set {},
+    },
+    Object {
+      "entity": null,
+      "style": Set {},
+    },
+    Object {
+      "entity": null,
+      "style": Set {},
+    },
+  ],
+  "data": Object {},
+  "depth": 0,
+  "key": "c",
+  "text": "Test",
+  "type": "code-block",
+}
+`;
+
+exports[`must apply multiple entities to different blocks 1`] = `
+Object {
+  "characterList": Array [
+    Object {
+      "entity": null,
+      "style": Set {},
+    },
+    Object {
+      "entity": "x",
+      "style": Set {},
+    },
+    Object {
+      "entity": null,
+      "style": Set {},
+    },
+    Object {
+      "entity": null,
+      "style": Set {},
+    },
+    Object {
+      "entity": null,
+      "style": Set {},
+    },
+  ],
+  "data": Object {},
+  "depth": 0,
+  "key": "a",
+  "text": "Alpha",
+  "type": "unstyled",
+}
+`;
+
+exports[`must apply multiple entities to different blocks 2`] = `
+Object {
+  "characterList": Array [
+    Object {
+      "entity": "2",
+      "style": Set {
+        "BOLD",
+      },
+    },
+    Object {
+      "entity": "y",
+      "style": Set {
+        "BOLD",
+      },
+    },
+    Object {
+      "entity": "y",
+      "style": Set {
+        "BOLD",
+      },
+    },
+    Object {
+      "entity": "2",
+      "style": Set {
+        "BOLD",
+      },
+    },
+    Object {
+      "entity": "2",
+      "style": Set {
+        "BOLD",
+      },
+    },
+  ],
+  "data": Object {},
+  "depth": 0,
+  "key": "b",
+  "text": "Bravo",
+  "type": "unordered-list-item",
+}
+`;
+
+exports[`must apply multiple entities to same block 1`] = `
+Object {
+  "characterList": Array [
+    Object {
+      "entity": null,
+      "style": Set {},
+    },
+    Object {
+      "entity": "x",
+      "style": Set {},
+    },
+    Object {
+      "entity": null,
+      "style": Set {},
+    },
+    Object {
+      "entity": "y",
+      "style": Set {},
+    },
+    Object {
+      "entity": null,
+      "style": Set {},
+    },
+  ],
+  "data": Object {},
+  "depth": 0,
+  "key": "a",
+  "text": "Alpha",
+  "type": "unstyled",
+}
+`;
+
 exports[`must apply null entity 1`] = `
 Object {
   "a": Object {

--- a/src/model/transaction/__tests__/applyEntityToContentBlock-test.ts
+++ b/src/model/transaction/__tests__/applyEntityToContentBlock-test.ts
@@ -9,7 +9,9 @@
  */
 
 import {makeContentBlock} from '../../immutable/ContentBlock';
-import applyEntityToContentBlock from '../applyEntityToContentBlock';
+import applyEntityToContentBlock, {
+  applyEntityToMutableCharacterList,
+} from '../applyEntityToContentBlock';
 import {blockToJson} from '../../../util/blockMapToJson';
 
 const sampleBlock = makeContentBlock({
@@ -42,4 +44,13 @@ test('must apply at the end', () => {
 
 test('must apply to the entire text', () => {
   assertApplyEntityToContentBlock(0, 5);
+});
+
+test('must apply to mutable character list', () => {
+  const charList = Array.from(sampleBlock.characterList);
+  applyEntityToMutableCharacterList(charList, 1, 4, 'x');
+  expect(charList).toMatchSnapshot();
+
+  applyEntityToMutableCharacterList(charList, 2, 3, 'y');
+  expect(charList).toMatchSnapshot();
 });

--- a/src/model/transaction/__tests__/applyEntityToContentState-test.ts
+++ b/src/model/transaction/__tests__/applyEntityToContentState-test.ts
@@ -9,13 +9,16 @@
 import getSampleStateForTesting from '../getSampleStateForTesting';
 import {makeSelectionState} from '../../immutable/SelectionState';
 import {getBlockAfter, getFirstBlock} from '../../immutable/ContentState';
-import applyEntityToContentState from '../applyEntityToContentState';
+import applyEntityToContentState, {
+  applyEntitiesToContentState,
+} from '../applyEntityToContentState';
 import {blockMapToJsonObject} from '../../../util/blockMapToJson';
 
 const {contentState, selectionState} = getSampleStateForTesting();
 
 const initialBlock = getFirstBlock(contentState);
-const secondBlock = getBlockAfter(contentState, initialBlock.key);
+const secondBlock = getBlockAfter(contentState, initialBlock.key)!;
+const thirdBlock = getBlockAfter(contentState, secondBlock.key)!;
 
 const selectBlock = makeSelectionState({
   anchorKey: initialBlock.key,
@@ -27,8 +30,8 @@ const selectBlock = makeSelectionState({
 const selectAdjacentBlocks = makeSelectionState({
   anchorKey: initialBlock.key,
   anchorOffset: 0,
-  focusKey: secondBlock?.key,
-  focusOffset: secondBlock?.text.length,
+  focusKey: secondBlock.key,
+  focusOffset: secondBlock.text.length,
 });
 
 const assertApplyEntityToContentState = (
@@ -57,4 +60,61 @@ test('must apply entity key accross multiple blocks', () => {
 
 test('must apply null entity key accross multiple blocks', () => {
   assertApplyEntityToContentState(null, selectAdjacentBlocks);
+});
+
+test('must apply multiple entities to same block', () => {
+  const selectionA = makeSelectionState({
+    anchorKey: initialBlock.key,
+    anchorOffset: 1,
+    focusKey: initialBlock.key,
+    focusOffset: 2,
+  });
+  const selectionB = makeSelectionState({
+    anchorKey: initialBlock.key,
+    anchorOffset: 3,
+    focusKey: initialBlock.key,
+    focusOffset: 4,
+  });
+  const blockMap = applyEntitiesToContentState(contentState, [
+    [selectionA, 'x'],
+    [selectionB, 'y'],
+  ]).blockMap;
+  expect(blockMap.get(initialBlock.key)).toMatchSnapshot();
+});
+
+test('must apply multiple entities to different blocks', () => {
+  const selectionA = makeSelectionState({
+    anchorKey: initialBlock.key,
+    anchorOffset: 1,
+    focusKey: initialBlock.key,
+    focusOffset: 2,
+  });
+  const selectionB = makeSelectionState({
+    anchorKey: secondBlock.key,
+    anchorOffset: 1,
+    focusKey: secondBlock.key,
+    focusOffset: 3,
+  });
+  const blockMap = applyEntitiesToContentState(contentState, [
+    [selectionA, 'x'],
+    [selectionB, 'y'],
+  ]).blockMap;
+  expect(blockMap.get(initialBlock.key)).toMatchSnapshot();
+  expect(blockMap.get(secondBlock.key)).toMatchSnapshot();
+});
+
+test('must apply multiple entities across multiple blocks', () => {
+  const selectionAcrossSecondThird = makeSelectionState({
+    anchorKey: secondBlock.key,
+    anchorOffset: secondBlock.text.length - 1,
+    focusKey: thirdBlock.key,
+    focusOffset: 1,
+  });
+  const blockMap = applyEntitiesToContentState(contentState, [
+    [selectAdjacentBlocks, 'x'],
+    [selectionAcrossSecondThird, 'y'],
+  ]).blockMap;
+  expect(blockMap.get(initialBlock.key)).toMatchSnapshot();
+  expect(blockMap.get(secondBlock.key)).toMatchSnapshot();
+  expect(blockMap.get(thirdBlock.key)).toMatchSnapshot();
 });

--- a/src/model/transaction/applyEntityToContentBlock.ts
+++ b/src/model/transaction/applyEntityToContentBlock.ts
@@ -40,3 +40,16 @@ export default function applyEntityToContentBlock(
       }
     : contentBlock;
 }
+
+export function applyEntityToMutableCharacterList(
+  characterList: CharacterMetadata[],
+  start: number,
+  end: number,
+  entityKey: string | null,
+): void {
+  for (let i = start; i < end; i++) {
+    if (characterList[i].entity !== entityKey) {
+      characterList[i] = applyEntity(characterList[i], entityKey);
+    }
+  }
+}

--- a/src/model/transaction/applyEntityToContentBlock.ts
+++ b/src/model/transaction/applyEntityToContentBlock.ts
@@ -7,7 +7,7 @@
  * @emails oncall+draft_js
  */
 
-import {applyEntity} from '../immutable/CharacterMetadata';
+import {applyEntity, CharacterMetadata} from '../immutable/CharacterMetadata';
 import {BlockNode} from '../immutable/BlockNode';
 
 export default function applyEntityToContentBlock(
@@ -20,17 +20,20 @@ export default function applyEntityToContentBlock(
   if (start >= end) {
     return contentBlock;
   }
-  const characterList = Array.from(contentBlock.characterList);
-  let didChange = false;
+
+  const existingCharacterList = contentBlock.characterList;
+  let characterList: CharacterMetadata[] | undefined;
 
   while (start < end) {
-    if (!didChange && characterList[start].entity !== entityKey) {
-      didChange = true;
+    if (!characterList && existingCharacterList[start].entity !== entityKey) {
+      characterList = Array.from(existingCharacterList);
     }
-    characterList[start] = applyEntity(characterList[start], entityKey);
+    if (characterList) {
+      characterList[start] = applyEntity(characterList[start], entityKey);
+    }
     start++;
   }
-  return didChange
+  return characterList
     ? {
         ...contentBlock,
         characterList,

--- a/src/model/transaction/applyEntityToContentState.ts
+++ b/src/model/transaction/applyEntityToContentState.ts
@@ -17,8 +17,43 @@ import {
 } from '../immutable/SelectionState';
 import {flatten, map, skipUntil, takeUntil} from '../descript/Iterables';
 import applyEntityToContentBlock from './applyEntityToContentBlock';
-import {mergeMapUpdates} from '../immutable/BlockMap';
+import {
+  makeBlockMapIndex,
+  BlockMapIndex,
+  mergeMapUpdates,
+  BlockMap,
+} from '../immutable/BlockMap';
 import {BlockNode} from '../immutable/BlockNode';
+
+function updateNewBlocksWithEntity(
+  blockMap: BlockMap,
+  blockMapIndex: BlockMapIndex,
+  newBlocks: Record<string, BlockNode>,
+  selectionState: SelectionState,
+  entityKey: string | null,
+): void {
+  const startKey = getStartKey(selectionState);
+  const startOffset = getStartOffset(selectionState);
+  const endKey = getEndKey(selectionState);
+  const endOffset = getEndOffset(selectionState);
+
+  let blockKey: string | null = startKey;
+  while (blockKey) {
+    const block = newBlocks[blockKey] || blockMap.get(blockKey);
+    const sliceStart = blockKey === startKey ? startOffset : 0;
+    const sliceEnd = blockKey === endKey ? endOffset : block.text.length;
+    newBlocks[blockKey] = applyEntityToContentBlock(
+      block,
+      sliceStart,
+      sliceEnd,
+      entityKey,
+    );
+    if (blockKey === endKey) {
+      return;
+    }
+    blockKey = blockMapIndex[blockKey];
+  }
+}
 
 export default function applyEntityToContentState(
   contentState: ContentState,
@@ -59,5 +94,36 @@ export default function applyEntityToContentState(
     blockMap: mergeMapUpdates(blockMap, newBlocks),
     selectionBefore: selectionState,
     selectionAfter: selectionState,
+  };
+}
+
+export function applyEntitiesToContentState(
+  contentState: ContentState,
+  entities: Iterable<[SelectionState, string | null]>,
+): ContentState {
+  const blockMap = contentState.blockMap;
+  const blockMapIndex = makeBlockMapIndex(blockMap);
+  const newBlocks: Record<string, BlockNode> = {};
+  let lastSelectionState: SelectionState | undefined;
+  for (const [selectionState, entityKey] of entities) {
+    updateNewBlocksWithEntity(
+      blockMap,
+      blockMapIndex,
+      newBlocks,
+      selectionState,
+      entityKey,
+    );
+    lastSelectionState = selectionState;
+  }
+
+  return {
+    ...contentState,
+    blockMap: mergeMapUpdates(blockMap, newBlocks),
+    ...(lastSelectionState
+      ? {
+          selectionBefore: lastSelectionState,
+          selectionAfter: lastSelectionState,
+        }
+      : {}),
   };
 }

--- a/src/model/transaction/applyEntityToContentState.ts
+++ b/src/model/transaction/applyEntityToContentState.ts
@@ -20,7 +20,7 @@ import applyEntityToContentBlock, {
   applyEntityToMutableCharacterList,
 } from './applyEntityToContentBlock';
 import {
-  makeBlockMapIndex,
+  makeNextBlockKeyIndex,
   BlockMapIndex,
   mergeMapUpdates,
   BlockMap,
@@ -31,7 +31,7 @@ import {CharacterMetadata} from '../immutable/CharacterMetadata';
 function updateNewBlocksWithEntity(
   blockMap: BlockMap,
   blockMapIndex: BlockMapIndex,
-  newCharacterLists: Map<string, CharacterMetadata[]>,
+  newBlockCharacterLists: Map<string, CharacterMetadata[]>, // keys are block keys
   selectionState: SelectionState,
   entityKey: string | null,
 ): void {
@@ -42,14 +42,14 @@ function updateNewBlocksWithEntity(
 
   let blockKey: string | null = startKey;
   while (blockKey) {
-    let characterList = newCharacterLists.get(blockKey);
+    let characterList = newBlockCharacterLists.get(blockKey);
     if (!characterList) {
       const existingBlock = blockMap.get(blockKey);
       if (!existingBlock) {
         throw new Error('Could not get block for key');
       }
       characterList = Array.from(existingBlock.characterList);
-      newCharacterLists.set(blockKey, characterList);
+      newBlockCharacterLists.set(blockKey, characterList);
     }
 
     const sliceStart = blockKey === startKey ? startOffset : 0;
@@ -114,20 +114,20 @@ export function applyEntitiesToContentState(
   entities: Iterable<[SelectionState, string | null]>,
 ): ContentState {
   const blockMap = contentState.blockMap;
-  const blockMapIndex = makeBlockMapIndex(blockMap);
-  const newCharacterLists = new Map<string, CharacterMetadata[]>();
+  const blockMapIndex = makeNextBlockKeyIndex(blockMap);
+  const newBlockCharacterLists = new Map<string, CharacterMetadata[]>();
   for (const [selectionState, entityKey] of entities) {
     updateNewBlocksWithEntity(
       blockMap,
       blockMapIndex,
-      newCharacterLists,
+      newBlockCharacterLists,
       selectionState,
       entityKey,
     );
   }
 
   const newBlocks: Record<string, BlockNode> = {};
-  for (const [key, list] of newCharacterLists) {
+  for (const [key, list] of newBlockCharacterLists) {
     const block = blockMap.get(key);
     if (!block) {
       throw new Error('Could not get block for key');


### PR DESCRIPTION
Adds a new function `Modifiers.applyEntities` that efficiently adds entities to corresponding selections. This is more efficient than calling `Modifieres.applyEntity` in a loop because it only regenerates `ContentState` (via `mergeMapUpdates`) once.

### Tests

- [x] Unit tests