### PR TITLE
Changes in DOMObserver to handle multiple text changes (i.e., with macOS dictation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@descript/draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.11.6-descript.10",
+  "version": "0.11.6-descript.11",
   "keywords": [
     "draftjs",
     "editor",

--- a/src/component/handlers/composition/DOMObserver.ts
+++ b/src/component/handlers/composition/DOMObserver.ts
@@ -95,11 +95,10 @@ export default class DOMObserver {
     return mutations;
   }
 
-  registerMutations(mutations: MutationRecordT[]): void {
+  registerMutations(mutations: readonly MutationRecordT[]): void {
     const mutationsToProcess = new Map<Node, MutationRecordT>();
 
-    for (let i = 0; i < mutations.length; i++) {
-      const mutation = mutations[i];
+    for (const mutation of mutations) {
       // Sometimes we get multiple mutations for the same target.
       // Only process the latest.
       mutationsToProcess.set(mutation.target, mutation);


### PR DESCRIPTION
WIP on adjusting DOMObserver to work better with macOS dictation. The previous logic was taking the final mutation for each `offsetKey`, but there were cases in macOS dictation where there are multiple entries for a single offset key (and they should all be preserved). For example, if you say "Hello newline Testing" macOS dictation will eventually translate this into two separate nodes in the ContentEditable.

This PR combines mutation text where possible. It also stops looking at `childList` because, for our purposes at least, I couldn't see an advantage to that over sticking with `characterData`.
