### PR TITLE
fix error when double space is detected with decorator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@descript/draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.11.6-descript.11",
+  "version": "0.11.6-descript.12",
   "keywords": [
     "draftjs",
     "editor",

--- a/src/component/handlers/edit/editOnBeforeInput.ts
+++ b/src/component/handlers/edit/editOnBeforeInput.ts
@@ -24,6 +24,7 @@ import isEventHandled from '../../utils/isEventHandled';
 import {
   getStartOffset,
   isCollapsed,
+  makeSelectionState,
 } from '../../../model/immutable/SelectionState';
 import getEntityKeyForSelection from '../../../model/entity/getEntityKeyForSelection';
 import isSelectionAtLeafStart from '../../selection/isSelectionAtLeafStart';
@@ -60,9 +61,20 @@ function replaceText(
   entityKey: string | null,
   forceSelection: boolean,
 ): EditorState {
+  // Special case '. ': Replace ' ' with '. '
+  // https://github.com/facebook/draft-js/issues/2422#issuecomment-683221263
+  let selection = editorState.selection;
+
+  if (text === '. ') {
+    selection = makeSelectionState({
+      ...selection,
+      anchorOffset: selection.anchorOffset - 1,
+    });
+  }
+
   const contentState = DraftModifier.replaceText(
     editorState.currentContent,
-    editorState.selection,
+    selection,
     text,
     inlineStyle,
     entityKey,

--- a/src/component/handlers/edit/editOnBeforeInput.ts
+++ b/src/component/handlers/edit/editOnBeforeInput.ts
@@ -65,7 +65,11 @@ function replaceText(
   // https://github.com/facebook/draft-js/issues/2422#issuecomment-683221263
   let selection = editorState.selection;
 
-  if (text === '. ') {
+  if (
+    text === '. ' &&
+    selection.anchorKey === selection.focusKey &&
+    selection.anchorOffset > 0
+  ) {
     selection = makeSelectionState({
       ...selection,
       anchorOffset: selection.anchorOffset - 1,


### PR DESCRIPTION
https://github.com/facebook/draft-js/issues/2422#issuecomment-683221263

I'm adding a feature to the Descript comment box where email are detected on space. When a user hits double space it causes the app to crash because of the above. This fix from the GitHub issue makes the code work 🎉 


https://user-images.githubusercontent.com/1192452/119065701-f911f700-b992-11eb-867a-97d693a7dd9b.mov

