### PR TITLE
Do not scroll to bottom of block if selection is collapsed

### DIFF
--- a/src/component/contents/DraftEditorBlock.react.tsx
+++ b/src/component/contents/DraftEditorBlock.react.tsx
@@ -21,7 +21,11 @@ import getViewportDimensions from 'fbjs/lib/getViewportDimensions';
 import {ContentState} from '../../model/immutable/ContentState';
 import {DraftInlineStyle} from '../../model/immutable/DraftInlineStyle';
 import {DraftDecoratorType} from '../../model/decorators/DraftDecoratorType';
-import {getEndKey, SelectionState} from '../../model/immutable/SelectionState';
+import {
+  getEndKey,
+  isCollapsed,
+  SelectionState,
+} from '../../model/immutable/SelectionState';
 import invariant from '../../fbjs/invariant';
 import isHTMLElement from '../utils/isHTMLElement';
 import {DecoratorRange} from '../../model/immutable/BlockTree';
@@ -129,6 +133,12 @@ export default class DraftEditorBlock extends React.Component<Props> {
     const selection = this.props.selection;
     const endKey = getEndKey(selection);
     if (!selection.hasFocus || endKey !== this.props.block.key) {
+      return;
+    }
+
+    // If user hits return, selection would be at the beginning of the new block, we do not
+    // want to scroll to the bottom of the block.
+    if (isCollapsed(selection)) {
       return;
     }
 

--- a/src/component/contents/__tests__/DraftEditorBlock.react-test.tsx
+++ b/src/component/contents/__tests__/DraftEditorBlock.react-test.tsx
@@ -451,7 +451,17 @@ test('must split styled spans apart within decorator', () => {
 });
 
 test('must scroll the window if needed', () => {
-  const props = getProps(getHelloBlock());
+  const props = {
+    ...getProps(getHelloBlock()),
+    selection: makeSelectionState({
+      anchorKey: 'a',
+      anchorOffset: 0,
+      focusKey: 'a',
+      focusOffset: 2,
+      isBackward: false,
+      hasFocus: true,
+    }),
+  };
 
   getElementPosition.mockReturnValueOnce({
     x: 0,


### PR DESCRIPTION
**Summary**

We have a bug where entering new line scrolls to the bottom of the new paragraph, which is jarring when the new paragraph is long. See more context in my linear comment: https://linear.app/descript/issue/ED-3629#comment-45493ecd

**Test Plan**

- [x] no longer scrolls to bottom of paragraph when hitting enter:

https://user-images.githubusercontent.com/1612169/165378161-30e38074-85ee-4640-9ef2-7573911c9016.mp4


https://user-images.githubusercontent.com/1612169/165378203-808ff2fd-269e-4b0f-ac6b-50bf3476511f.mp4


