### PR TITLE
Adds electron user agent to isChromium check

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [12.x]
 
     steps:
       - uses: actions/checkout@v1

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@descript/draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.11.6-descript.13",
+  "version": "0.11.6-descript.14",
   "keywords": [
     "draftjs",
     "editor",

--- a/src/component/handlers/edit/DraftEditorEditHandler.ts
+++ b/src/component/handlers/edit/DraftEditorEditHandler.ts
@@ -23,7 +23,8 @@ import {editOnKeyDown} from './editOnKeyDown';
 import editOnPaste from './editOnPaste';
 import editOnSelect from './editOnSelect';
 
-const isChromium = UserAgent.isBrowser('Chrome') || UserAgent.isBrowser('Electron');
+const isChromium =
+  UserAgent.isBrowser('Chrome') || UserAgent.isBrowser('Electron');
 const isFirefox = UserAgent.isBrowser('Firefox');
 
 const selectionHandler: (e: DraftEditor) => void =

--- a/src/component/handlers/edit/DraftEditorEditHandler.ts
+++ b/src/component/handlers/edit/DraftEditorEditHandler.ts
@@ -23,11 +23,11 @@ import {editOnKeyDown} from './editOnKeyDown';
 import editOnPaste from './editOnPaste';
 import editOnSelect from './editOnSelect';
 
-const isChrome = UserAgent.isBrowser('Chrome');
+const isChromium = UserAgent.isBrowser('Chrome') || UserAgent.isBrowser('Electron');
 const isFirefox = UserAgent.isBrowser('Firefox');
 
 const selectionHandler: (e: DraftEditor) => void =
-  isChrome || isFirefox
+  isChromium || isFirefox
     ? editOnSelect
     : _ => {
         //

--- a/src/component/handlers/edit/editOnKeyDown.ts
+++ b/src/component/handlers/edit/editOnKeyDown.ts
@@ -34,7 +34,8 @@ import DraftModifier from '../../../model/modifier/DraftModifier';
 import keyCommandUndo from './commands/keyCommandUndo';
 
 const {isOptionKeyCommand} = KeyBindingUtil;
-const isChromium = UserAgent.isBrowser('Chrome') || UserAgent.isBrowser('Electron');
+const isChromium =
+  UserAgent.isBrowser('Chrome') || UserAgent.isBrowser('Electron');
 
 /**
  * Map a `DraftEditorCommand` command value to a corresponding function.

--- a/src/component/handlers/edit/editOnKeyDown.ts
+++ b/src/component/handlers/edit/editOnKeyDown.ts
@@ -34,7 +34,7 @@ import DraftModifier from '../../../model/modifier/DraftModifier';
 import keyCommandUndo from './commands/keyCommandUndo';
 
 const {isOptionKeyCommand} = KeyBindingUtil;
-const isChrome = UserAgent.isBrowser('Chrome');
+const isChromium = UserAgent.isBrowser('Chrome') || UserAgent.isBrowser('Electron');
 
 /**
  * Map a `DraftEditorCommand` command value to a corresponding function.
@@ -159,7 +159,7 @@ export function editOnKeyDown(
       break;
     case Keys.SPACE:
       // Prevent Chrome on OSX behavior where option + space scrolls.
-      if (isChrome && isOptionKeyCommand(e)) {
+      if (isChromium && isOptionKeyCommand(e)) {
         e.preventDefault();
       }
   }
@@ -168,7 +168,7 @@ export function editOnKeyDown(
 
   // If no command is specified, allow keydown event to continue.
   if (command == null || command === '') {
-    if (keyCode === Keys.SPACE && isChrome && isOptionKeyCommand(e)) {
+    if (keyCode === Keys.SPACE && isChromium && isOptionKeyCommand(e)) {
       // The default keydown event has already been prevented in order to stop
       // Chrome from scrolling. Insert a nbsp into the editor as OSX would for
       // other browsers.

--- a/src/component/selection/getRangeClientRects.ts
+++ b/src/component/selection/getRangeClientRects.ts
@@ -10,7 +10,8 @@
 import UserAgent from 'fbjs/lib/UserAgent';
 import invariant from '../../fbjs/invariant';
 
-const isChromium = UserAgent.isBrowser('Chrome') || UserAgent.isBrowser('Electron');
+const isChromium =
+  UserAgent.isBrowser('Chrome') || UserAgent.isBrowser('Electron');
 
 // In Chrome, the client rects will include the entire bounds of all nodes that
 // begin (have a start tag) within the selection, even if the selection does

--- a/src/component/selection/getRangeClientRects.ts
+++ b/src/component/selection/getRangeClientRects.ts
@@ -10,7 +10,7 @@
 import UserAgent from 'fbjs/lib/UserAgent';
 import invariant from '../../fbjs/invariant';
 
-const isChrome = UserAgent.isBrowser('Chrome');
+const isChromium = UserAgent.isBrowser('Chrome') || UserAgent.isBrowser('Electron');
 
 // In Chrome, the client rects will include the entire bounds of all nodes that
 // begin (have a start tag) within the selection, even if the selection does
@@ -56,7 +56,7 @@ function getRangeClientRectsChrome(range: Range): Array<ClientRect> {
 /**
  * Like range.getClientRects() but normalizes for browser bugs.
  */
-const getRangeClientRects = isChrome
+const getRangeClientRects = isChromium
   ? getRangeClientRectsChrome
   : (function(range: Range): Array<ClientRect> {
       return Array.from(range.getClientRects());


### PR DESCRIPTION
There are a few Chrome-specific fixes in draft.js that we weren't pulling in because the Electron user agent is not Chrome.

Fixes ED-6481