### PR TITLE
scroll to new block if new block is empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@descript/draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.11.6-descript.14",
+  "version": "0.11.6-descript.15",
   "keywords": [
     "draftjs",
     "editor",

--- a/src/component/contents/DraftEditorBlock.react.tsx
+++ b/src/component/contents/DraftEditorBlock.react.tsx
@@ -136,9 +136,9 @@ export default class DraftEditorBlock extends React.Component<Props> {
       return;
     }
 
-    // If user hits return, selection would be at the beginning of the new block, we do not
-    // want to scroll to the bottom of the block.
-    if (isCollapsed(selection)) {
+    // If user hits return in the middle of an existing block (i.e. the new block
+    // has non-empty text), we do not want to scroll to the bottom of the block.
+    if (isCollapsed(selection) && this.props.block.text.length !== 0) {
       return;
     }
 


### PR DESCRIPTION
We have a bug where hitting enter to make new lines does not scroll to the new line. This is a regression from #25, where when hitting enter in the middle of an existing block, we do not want to scroll to the end of the new block.

The fix is to scroll to the end of the new block if the new block is empty.

Tested in the plaintext example after setting the container div to a fixed height with `scroll: auto`.

https://user-images.githubusercontent.com/1612169/209240754-7d690247-1436-45bb-878c-c5114d892dd2.mov





https://user-images.githubusercontent.com/1612169/209240750-09067907-0948-4612-b465-b926c8c28962.mov

