### PR TITLE
Allow override of onInput handler in edit mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@descript/draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.11.6-descript.24",
+  "version": "0.11.6-descript.25",
   "keywords": [
     "draftjs",
     "editor",

--- a/src/component/base/DraftEditor.react.tsx
+++ b/src/component/base/DraftEditor.react.tsx
@@ -578,29 +578,21 @@ export default class DraftEditor extends React.Component<
   setMode: (draftEditorModes: DraftEditorModes) => void = (
     mode: DraftEditorModes,
   ): void => {
-    const {onPaste, onCut, onCopy} = this.props;
-    const editHandler = {...handlerMap.edit};
+    const {onPaste, onCut, onCopy, onInput} = this.props;
 
-    if (onPaste) {
-      /* $FlowFixMe(>=0.117.0 site=www,mobile) This comment suppresses an error found
-       * when Flow v0.117 was deployed. To see the error delete this comment
-       * and run Flow. */
-      editHandler.onPaste = onPaste;
+    if (mode === 'edit') {
+      const editHandler = handlerMap.edit;
+      this._handler = {
+        ...editHandler,
+        onInput: onInput || editHandler.onInput,
+        onCopy: onCopy || editHandler.onCopy,
+        onCut: onCut || editHandler.onCut,
+        onPaste: onPaste || editHandler.onPaste,
+      };
+    } else {
+      this._handler = handlerMap[mode];
     }
 
-    if (onCut) {
-      editHandler.onCut = onCut;
-    }
-
-    if (onCopy) {
-      editHandler.onCopy = onCopy;
-    }
-
-    const handler = {
-      ...handlerMap,
-      edit: editHandler,
-    };
-    this._handler = handler[mode];
     this.mode = mode;
 
     if (mode !== 'drag') {

--- a/src/component/base/DraftEditorProps.ts
+++ b/src/component/base/DraftEditorProps.ts
@@ -20,7 +20,10 @@ import {DraftInlineStyle} from '../../model/immutable/DraftInlineStyle';
 import {DraftBlockRenderMap} from '../../model/immutable/DraftBlockRenderMap';
 import {CSSProperties} from 'react';
 import DraftEditor from './DraftEditor.react';
-import {SyntheticClipboardEvent} from '../utils/eventTypes';
+import {
+  SyntheticClipboardEvent,
+  SyntheticInputEvent,
+} from '../utils/eventTypes';
 import {BlockNode} from '../../model/immutable/BlockNode';
 
 export type DraftEditorProps = {
@@ -204,6 +207,19 @@ export type DraftEditorProps = {
   onCopy?: (
     draftEditor: DraftEditor,
     syntheticClipboardEvent: SyntheticClipboardEvent,
+  ) => void;
+
+  /**
+   * Override the default behavior for the editor's `onInput` handler in edit mode.
+   * The draft.js implementation is typically an important feature of draft.js
+   * but if the user is attempting to fully control the input (e.g., via
+   * overriding `handleBeforeInput` then they might want to override this
+   * in order to provide error handling in the unexpected event that we do
+   * end up in this handler).
+   */
+  onInput?: (
+    draftEditor: DraftEditor,
+    syntheticClipboardEvent: SyntheticInputEvent,
   ) => void;
 
   /**


### PR DESCRIPTION
We are fully controlling the draft.js component, and we _never_ want the default onInput to be used. That implies that there's a bug in our decorators that allowed a contenteditable change that did not go through our `onBeforeInput` handler. By allowing us to override `onInput`, we'll be able to (a) recover from the bug by calling `editor.restoreEditorDOM()` and also (b) log more details about how this was happening in the first place (e.g., the event's `inputType`) so we can eventually fix the bug.