### PR TITLE
Prevent default for input events that don't have any characters

### DIFF
--- a/src/component/handlers/edit/editOnBeforeInput.ts
+++ b/src/component/handlers/edit/editOnBeforeInput.ts
@@ -116,6 +116,7 @@ export default function editOnBeforeInput(
   // In some cases (ex: IE ideographic space insertion) no character data
   // is provided. There's nothing to do when this happens.
   if (!chars) {
+    e.preventDefault();
     return;
   }
 


### PR DESCRIPTION
Seeing cases where some input events with `inputType=deleteContentBackward` are slipping through. These are probably being created via some mechanism other than a keydown directly on the script (e.g., through some accessibility API, or touch control, or some event that's being targeted elsewhere but propagating to the script accidentally).

We _never_ want draft.js to do anything in response to an `onInput` in our user case. We were relying on our passed-in `handleBeforeInput` to always return `handled`; but we're only hitting that logic when the input event contains characters. This will hopefully fix that.

(All of the Sentry errors that show an input event slipping through have the inputType `deleteContentBackward`, e.g., https://descript-inc.sentry.io/issues/5906595861/events/ccbc41ddbc754203babb78ff9d929d93/?project=1197057&referrer=previous-event)
