### PR TITLE
Additional type exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@descript/draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.11.6-descript.29",
+  "version": "0.11.6-descript.30",
   "keywords": [
     "draftjs",
     "editor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@descript/draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.11.6-descript.31",
+  "version": "0.11.6-descript.32",
   "keywords": [
     "draftjs",
     "editor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@descript/draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.11.6-descript.33",
+  "version": "0.11.6-descript.34",
   "keywords": [
     "draftjs",
     "editor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@descript/draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.11.6-descript.28",
+  "version": "0.11.6-descript.29",
   "keywords": [
     "draftjs",
     "editor",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,14 @@
     "react": ">=16.0.0",
     "react-dom": ">=16.0.0"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    },
+    "@types/react-dom": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@babel/core": "^7.6.4",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@descript/draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.11.6-descript.30",
+  "version": "0.11.6-descript.31",
   "keywords": [
     "draftjs",
     "editor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@descript/draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.11.6-descript.32",
+  "version": "0.11.6-descript.33",
   "keywords": [
     "draftjs",
     "editor",

--- a/src/Draft.ts
+++ b/src/Draft.ts
@@ -10,6 +10,7 @@
 import Editor from './component/base/DraftEditor.react';
 export {Editor};
 import DraftEditorBlock from './component/contents/DraftEditorBlock.react';
+export type {DraftEditorProps} from './component/base/DraftEditorProps';
 export {CompositeDecorator} from './model/decorators/CompositeDraftDecorator';
 import DraftEntity from './model/entity/DraftEntity';
 import AtomicBlockUtils from './model/modifier/AtomicBlockUtils';
@@ -54,4 +55,5 @@ export * from './model/immutable/DraftInlineStyle';
 export * from './model/immutable/findRangesImmutable';
 export * from './model/immutable/BlockNode';
 export * from './model/immutable/BlockTree';
+export * from './model/immutable/EditorChangeType';
 export * from './model/entity/DraftEntityInstance';

--- a/src/Draft.ts
+++ b/src/Draft.ts
@@ -10,7 +10,7 @@
 import Editor from './component/base/DraftEditor.react';
 export {Editor};
 import DraftEditorBlock from './component/contents/DraftEditorBlock.react';
-import CompositeDraftDecorator from './model/decorators/CompositeDraftDecorator';
+export * as CompositeDecorator from './model/decorators/CompositeDraftDecorator';
 import DraftEntity from './model/entity/DraftEntity';
 import AtomicBlockUtils from './model/modifier/AtomicBlockUtils';
 export {AtomicBlockUtils};
@@ -41,7 +41,6 @@ export type {DraftDecoratorType} from './model/decorators/DraftDecoratorType';
 export type {DraftDecorator, DraftDecoratorComponentProps} from './model/decorators/DraftDecorator';
 
 export const EditorBlock = DraftEditorBlock;
-export const CompositeDecorator = CompositeDraftDecorator;
 export const Entity = DraftEntity;
 
 export * from './model/immutable/BlockMapBuilder';

--- a/src/Draft.ts
+++ b/src/Draft.ts
@@ -38,6 +38,7 @@ export type {RawDraftContentState} from './model/encoding/convertFromDraftStateT
 export type {DraftEditorCommand} from './model/constants/DraftEditorCommand';
 export type {DraftHandleValue} from './model/constants/DraftHandleValue';
 export type {DraftDecoratorType} from './model/decorators/DraftDecoratorType';
+export type {DraftDecorator, DraftDecoratorComponentProps} from './model/decorators/DraftDecorator';
 
 export const EditorBlock = DraftEditorBlock;
 export const CompositeDecorator = CompositeDraftDecorator;

--- a/src/Draft.ts
+++ b/src/Draft.ts
@@ -30,12 +30,14 @@ import getDefaultKeyBinding from './component/utils/getDefaultKeyBinding';
 export {getDefaultKeyBinding};
 import getVisibleSelectionRect from './component/selection/getVisibleSelectionRect';
 export {getVisibleSelectionRect};
+export type {SyntheticInputEvent, SyntheticClipboardEvent} from './component/utils/eventTypes';
 import convertFromDraftStateToRaw from './model/encoding/convertFromDraftStateToRaw';
 export {convertFromDraftStateToRaw};
 export type {RawDraftContentState} from './model/encoding/convertFromDraftStateToRaw';
 
 export type {DraftEditorCommand} from './model/constants/DraftEditorCommand';
 export type {DraftHandleValue} from './model/constants/DraftHandleValue';
+export type {DraftDecoratorType} from './model/decorators/DraftDecoratorType';
 
 export const EditorBlock = DraftEditorBlock;
 export const CompositeDecorator = CompositeDraftDecorator;

--- a/src/Draft.ts
+++ b/src/Draft.ts
@@ -10,7 +10,7 @@
 import Editor from './component/base/DraftEditor.react';
 export {Editor};
 import DraftEditorBlock from './component/contents/DraftEditorBlock.react';
-export * as CompositeDecorator from './model/decorators/CompositeDraftDecorator';
+export {CompositeDecorator} from './model/decorators/CompositeDraftDecorator';
 import DraftEntity from './model/entity/DraftEntity';
 import AtomicBlockUtils from './model/modifier/AtomicBlockUtils';
 export {AtomicBlockUtils};

--- a/src/component/handlers/edit/__tests__/editOnBeforeInput-test.ts
+++ b/src/component/handlers/edit/__tests__/editOnBeforeInput-test.ts
@@ -25,7 +25,7 @@ import {
 import DraftEditor from '../../../base/DraftEditor.react';
 import {SyntheticInputEvent} from '../../../utils/eventTypes';
 import editOnBeforeInput from '../editOnBeforeInput';
-import CompositeDecorator from '../../../../model/decorators/CompositeDraftDecorator';
+import {CompositeDecorator} from '../../../../model/decorators/CompositeDraftDecorator';
 
 const DEFAULT_SELECTION = {
   anchorKey: 'a',

--- a/src/component/handlers/edit/__tests__/editOnBeforeInput-test.ts
+++ b/src/component/handlers/edit/__tests__/editOnBeforeInput-test.ts
@@ -25,7 +25,7 @@ import {
 import DraftEditor from '../../../base/DraftEditor.react';
 import {SyntheticInputEvent} from '../../../utils/eventTypes';
 import editOnBeforeInput from '../editOnBeforeInput';
-import CompositeDraftDecorator from '../../../../model/decorators/CompositeDraftDecorator';
+import CompositeDecorator from '../../../../model/decorators/CompositeDraftDecorator';
 
 const DEFAULT_SELECTION = {
   anchorKey: 'a',
@@ -178,7 +178,7 @@ function testDecoratorFingerprint(
 ) {
   const editorState = acceptSelection(
     setEditorState(getEditorState(text), {
-      decorator: new CompositeDraftDecorator([
+      decorator: new CompositeDecorator([
         {
           strategy: hashtagStrategy,
           component: () => null,
@@ -202,7 +202,9 @@ function testDecoratorFingerprint(
   const ev = getInputEvent(charToInsert);
   editOnBeforeInput(editor, ev);
 
-  expect((ev.preventDefault as jest.Mock).mock.calls.length).toBe(shouldPrevent ? 1 : 0);
+  expect((ev.preventDefault as jest.Mock).mock.calls.length).toBe(
+    shouldPrevent ? 1 : 0,
+  );
 }
 
 test('decorator fingerprint logic bails out of native insertion', () => {

--- a/src/model/decorators/CompositeDraftDecorator.ts
+++ b/src/model/decorators/CompositeDraftDecorator.ts
@@ -33,7 +33,7 @@ const DELIMITER = '.';
  * Thus, when a collision like this is encountered, the earlier match is
  * preserved and the new match is discarded.
  */
-export default class CompositeDecorator {
+export class CompositeDecorator {
   _decorators: ReadonlyArray<DraftDecorator>;
 
   constructor(decorators: ReadonlyArray<DraftDecorator>) {

--- a/src/model/decorators/CompositeDraftDecorator.ts
+++ b/src/model/decorators/CompositeDraftDecorator.ts
@@ -15,7 +15,7 @@ import {ComponentType} from 'react';
 const DELIMITER = '.';
 
 /**
- * A CompositeDraftDecorator traverses through a list of DraftDecorator
+ * A CompositeDecorator traverses through a list of DraftDecorator
  * instances to identify sections of a ContentBlock that should be rendered
  * in a "decorated" manner. For example, hashtags, mentions, and links may
  * be intended to stand out visually, be rendered as anchors, etc.
@@ -33,7 +33,7 @@ const DELIMITER = '.';
  * Thus, when a collision like this is encountered, the earlier match is
  * preserved and the new match is discarded.
  */
-export default class CompositeDraftDecorator {
+export default class CompositeDecorator {
   _decorators: ReadonlyArray<DraftDecorator>;
 
   constructor(decorators: ReadonlyArray<DraftDecorator>) {

--- a/src/model/decorators/DraftDecorator.ts
+++ b/src/model/decorators/DraftDecorator.ts
@@ -38,7 +38,7 @@ export type DraftDecorator = {
   strategy: DraftDecoratorStrategy;
   component: ComponentType<{
     contentState: ContentState;
-    entityKey: string;
+    entityKey: string | null;
     children: React.ReactNode;
   }>;
   props?: Record<string, unknown>;

--- a/src/model/decorators/DraftDecorator.ts
+++ b/src/model/decorators/DraftDecorator.ts
@@ -36,11 +36,7 @@ export type DraftDecoratorStrategy = (
  */
 export type DraftDecorator = {
   strategy: DraftDecoratorStrategy;
-  component: ComponentType<{
-    contentState: ContentState;
-    entityKey: string | null;
-    children: React.ReactNode;
-  }>;
+  component: ComponentType<DraftDecoratorComponentProps>;
   props?: Record<string, unknown>;
 };
 

--- a/src/model/decorators/DraftDecoratorType.ts
+++ b/src/model/decorators/DraftDecoratorType.ts
@@ -10,7 +10,7 @@
 
 import {ContentState} from '../immutable/ContentState';
 import {BlockNode} from '../immutable/BlockNode';
-import {ComponentType} from 'react';
+import {ComponentType, ReactNode} from 'react';
 
 /**
  * An interface for document decorator classes, allowing the creation of
@@ -30,7 +30,13 @@ export type DraftDecoratorType = {
    * Given a decorator key, return the component to use when rendering
    * this decorated range.
    */
-  getComponentForKey: (key: string) => ComponentType;
+  getComponentForKey: (
+    key: string,
+  ) => ComponentType<{
+    contentState: ContentState;
+    entityKey: string | null;
+    children: ReactNode;
+  }>;
   /**
    * Given a decorator key, optionally return the props to use when rendering
    * this decorated range.

--- a/src/model/decorators/DraftDecoratorType.ts
+++ b/src/model/decorators/DraftDecoratorType.ts
@@ -10,7 +10,8 @@
 
 import {ContentState} from '../immutable/ContentState';
 import {BlockNode} from '../immutable/BlockNode';
-import {ComponentType, ReactNode} from 'react';
+import {ComponentType} from 'react';
+import {DraftDecoratorComponentProps} from './DraftDecorator';
 
 /**
  * An interface for document decorator classes, allowing the creation of
@@ -32,11 +33,7 @@ export type DraftDecoratorType = {
    */
   getComponentForKey: (
     key: string,
-  ) => ComponentType<{
-    contentState: ContentState;
-    entityKey: string | null;
-    children: ReactNode;
-  }>;
+  ) => ComponentType<DraftDecoratorComponentProps>;
   /**
    * Given a decorator key, optionally return the props to use when rendering
    * this decorated range.

--- a/src/model/decorators/DraftDecoratorType.ts
+++ b/src/model/decorators/DraftDecoratorType.ts
@@ -17,7 +17,7 @@ import {DraftDecoratorComponentProps} from './DraftDecorator';
  * An interface for document decorator classes, allowing the creation of
  * custom decorator classes.
  *
- * See `CompositeDraftDecorator` for the most common use case.
+ * See `CompositeDecorator` for the most common use case.
  */
 export type DraftDecoratorType = {
   /**

--- a/src/model/decorators/__tests__/CompositeDraftDecorator-test.ts
+++ b/src/model/decorators/__tests__/CompositeDraftDecorator-test.ts
@@ -9,7 +9,7 @@
  */
 
 import {createFromText} from '../../immutable/ContentState';
-import CompositeDecorator from '../CompositeDraftDecorator';
+import {CompositeDecorator} from '../CompositeDraftDecorator';
 import {ContentBlock, makeContentBlock} from '../../immutable/ContentBlock';
 import {genKey} from '../../../Draft';
 

--- a/src/model/decorators/__tests__/CompositeDraftDecorator-test.ts
+++ b/src/model/decorators/__tests__/CompositeDraftDecorator-test.ts
@@ -9,7 +9,7 @@
  */
 
 import {createFromText} from '../../immutable/ContentState';
-import CompositeDraftDecorator from '../CompositeDraftDecorator';
+import CompositeDecorator from '../CompositeDraftDecorator';
 import {ContentBlock, makeContentBlock} from '../../immutable/ContentBlock';
 import {genKey} from '../../../Draft';
 
@@ -45,7 +45,7 @@ const assertCompositeDraftDecorator = (
   decorators = [FooDecorator, BarDecorator],
 ) => {
   expect(
-    new CompositeDraftDecorator(decorators).getDecorations(
+    new CompositeDecorator(decorators).getDecorations(
       makeContentBlock({text, key: genKey()}),
       createFromText(text),
     ),


### PR DESCRIPTION
We were importing these from relative paths in the package. This PR exports those needed types from the index, instead.

- [x] Confirmed that these are working and sufficient via `file:` installation of the package and local typechecking. (Well, it fixes the import typechecking issues... but there are a whole host of new typechecking issues caused by the ambient react 18 type!)