### PR TITLE
feat: add block windowing support

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
   "repository": "facebook/draft-js",
   "license": "MIT",
   "scripts": {
-    "prepublish": "npm run build",
+    "prepublish": "pnpm run build",
     "pretest": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json",
-    "build": "npm run clean && npm run build:lib && npm run build:umd && npm run build:css",
+    "build": "pnpm run clean && pnpm run build:lib && pnpm run build:umd && pnpm run build:css",
     "build:lib": "vite build",
     "build:umd": "vite build --config vite.config.umd.ts",
     "build:css": "vite build --config vite.config.css.ts && rm -f dist/dummy.js",
@@ -49,7 +49,7 @@
     "format-docs": "prettier --config prettier.config.js --write \"docs/**/*.md\"",
     "format-docs:diff": "prettier --config prettier.config.js --list-different \"docs/**/*.md\"",
     "test": "cross-env NODE_ENV=test jest",
-    "test-ci": "cross-env NODE_ENV=test npm run lint && npm run test"
+    "test-ci": "cross-env NODE_ENV=test pnpm run lint && pnpm run test"
   },
   "dependencies": {
     "fast-deep-equal": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@descript/draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.11.6-descript.34",
+  "version": "0.11.6-descript.35",
   "keywords": [
     "draftjs",
     "editor",

--- a/src/Draft.ts
+++ b/src/Draft.ts
@@ -10,7 +10,10 @@
 import Editor from './component/base/DraftEditor.react';
 export {Editor};
 import DraftEditorBlock from './component/contents/DraftEditorBlock.react';
-export type {DraftEditorProps} from './component/base/DraftEditorProps';
+export type {
+  DraftEditorBlockWindowing,
+  DraftEditorProps,
+} from './component/base/DraftEditorProps';
 export {CompositeDecorator} from './model/decorators/CompositeDraftDecorator';
 import DraftEntity from './model/entity/DraftEntity';
 import AtomicBlockUtils from './model/modifier/AtomicBlockUtils';

--- a/src/Draft.ts
+++ b/src/Draft.ts
@@ -14,6 +14,11 @@ export type {
   DraftEditorBlockWindowing,
   DraftEditorProps,
 } from './component/base/DraftEditorProps';
+export {
+  useDraftEditorBlockWindowing,
+  type DraftEditorBlockWindowingOptions,
+} from './component/hooks/useDraftEditorBlockWindowing';
+export {getDraftEditorWindowedTextOffset} from './component/contents/getDraftEditorWindowedTextOffset';
 export {CompositeDecorator} from './model/decorators/CompositeDraftDecorator';
 import DraftEntity from './model/entity/DraftEntity';
 import AtomicBlockUtils from './model/modifier/AtomicBlockUtils';

--- a/src/Draft.ts
+++ b/src/Draft.ts
@@ -11,13 +11,9 @@ import Editor from './component/base/DraftEditor.react';
 export {Editor};
 import DraftEditorBlock from './component/contents/DraftEditorBlock.react';
 export type {
-  DraftEditorBlockWindowing,
+  DraftEditorBlockWindowingOptions,
   DraftEditorProps,
 } from './component/base/DraftEditorProps';
-export {
-  useDraftEditorBlockWindowing,
-  type DraftEditorBlockWindowingOptions,
-} from './component/hooks/useDraftEditorBlockWindowing';
 export {
   getDraftEditorBlockKeyForTextOffset,
   getDraftEditorWindowedTextOffset,

--- a/src/Draft.ts
+++ b/src/Draft.ts
@@ -18,7 +18,10 @@ export {
   useDraftEditorBlockWindowing,
   type DraftEditorBlockWindowingOptions,
 } from './component/hooks/useDraftEditorBlockWindowing';
-export {getDraftEditorWindowedTextOffset} from './component/contents/getDraftEditorWindowedTextOffset';
+export {
+  getDraftEditorBlockKeyForTextOffset,
+  getDraftEditorWindowedTextOffset,
+} from './component/contents/getDraftEditorWindowedTextOffset';
 export {CompositeDecorator} from './model/decorators/CompositeDraftDecorator';
 import DraftEntity from './model/entity/DraftEntity';
 import AtomicBlockUtils from './model/modifier/AtomicBlockUtils';

--- a/src/component/base/DraftEditor.react.tsx
+++ b/src/component/base/DraftEditor.react.tsx
@@ -35,7 +35,7 @@ import {hasText} from '../../model/immutable/ContentState';
 import {nullthrows} from '../../fbjs/nullthrows';
 import DraftEditorPlaceholder from './DraftEditorPlaceholder.react';
 import {DefaultDraftInlineStyle} from '../../model/immutable/DefaultDraftInlineStyle';
-import DraftEditorContents from '../contents/DraftEditorContents-core.react';
+import DraftEditorWindowedContents from '../contents/DraftEditorWindowedContents.react';
 
 const isIE = UserAgent.isBrowser('IE');
 
@@ -195,6 +195,7 @@ export default class DraftEditor extends React.Component<
 
   editor: HTMLElement | null = null;
   editorContainer: HTMLElement | null = null;
+  _editorContainerRef: {current: HTMLElement | null} = {current: null};
   getEditorKey: () => string;
 
   constructor(props: DraftEditorProps) {
@@ -285,6 +286,7 @@ export default class DraftEditor extends React.Component<
     node: HTMLElement | null,
   ): void => {
     this.editorContainer = node;
+    this._editorContainerRef.current = node;
     // Instead of having a direct ref on the child, we'll grab it here.
     // This is safe as long as the rendered structure is static (which it is).
     // This lets the child support ref={props.editorRef} without merging refs.
@@ -473,9 +475,10 @@ export default class DraftEditor extends React.Component<
               all DraftEditorLeaf nodes so it's first in postorder traversal.
             */}
             <UpdateDraftEditorFlags editor={this} editorState={editorState} />
-            <DraftEditorContents
+            <DraftEditorWindowedContents
               {...editorContentsProps}
-              key={'contents' + this.state.contentsKey}
+              contentsKey={this.state.contentsKey}
+              editorContainerRef={this._editorContainerRef}
             />
           </div>
         </div>

--- a/src/component/base/DraftEditor.react.tsx
+++ b/src/component/base/DraftEditor.react.tsx
@@ -336,6 +336,7 @@ export default class DraftEditor extends React.Component<
       blockRenderMap,
       blockRendererFn,
       blockStyleFn,
+      blockWindowing,
       customStyleFn,
       customStyleMap,
       editorState,
@@ -377,6 +378,7 @@ export default class DraftEditor extends React.Component<
       blockRenderMap,
       blockRendererFn,
       blockStyleFn,
+      blockWindowing,
       customStyleMap: {
         ...DefaultDraftInlineStyle,
         ...customStyleMap,

--- a/src/component/base/DraftEditorProps.ts
+++ b/src/component/base/DraftEditorProps.ts
@@ -26,6 +26,11 @@ import {
 } from '../utils/eventTypes';
 import {BlockNode} from '../../model/immutable/BlockNode';
 
+export type DraftEditorBlockWindowing = {
+  shouldRenderBlock: (block: BlockNode) => boolean;
+  getSpacerHeight: (block: BlockNode) => number;
+};
+
 export type DraftEditorProps = {
   /**
    * The two most critical props are `editorState` and `onChange`.
@@ -60,6 +65,7 @@ export type DraftEditorProps = {
   blockRendererFn: (block: BlockNode) => any | null;
   // Function that returns a cx map corresponding to block-level styles.
   blockStyleFn: (block: BlockNode) => string | CSSProperties | undefined;
+  blockWindowing?: DraftEditorBlockWindowing;
   // If supplied, a ref which will be passed to the contenteditable.
   // Currently, only object refs are supported.
   editorRef?: RefObject<HTMLDivElement> | Ref<HTMLDivElement>;

--- a/src/component/base/DraftEditorProps.ts
+++ b/src/component/base/DraftEditorProps.ts
@@ -26,9 +26,10 @@ import {
 } from '../utils/eventTypes';
 import {BlockNode} from '../../model/immutable/BlockNode';
 
-export type DraftEditorBlockWindowing = {
-  shouldRenderBlock: (block: BlockNode) => boolean;
-  getSpacerHeight: (block: BlockNode) => number;
+export type DraftEditorBlockWindowingOptions = {
+  enabled: boolean;
+  scrollContainerRef: RefObject<HTMLElement>;
+  pinnedBlockKeys?: ReadonlySet<string>;
 };
 
 export type DraftEditorProps = {
@@ -65,7 +66,7 @@ export type DraftEditorProps = {
   blockRendererFn: (block: BlockNode) => any | null;
   // Function that returns a cx map corresponding to block-level styles.
   blockStyleFn: (block: BlockNode) => string | CSSProperties | undefined;
-  blockWindowing?: DraftEditorBlockWindowing;
+  blockWindowing?: DraftEditorBlockWindowingOptions;
   // If supplied, a ref which will be passed to the contenteditable.
   // Currently, only object refs are supported.
   editorRef?: RefObject<HTMLDivElement> | Ref<HTMLDivElement>;

--- a/src/component/base/__tests__/DraftEditor.react-test.tsx
+++ b/src/component/base/__tests__/DraftEditor.react-test.tsx
@@ -13,16 +13,52 @@ import {createEmpty, EditorState} from '../../../model/immutable/EditorState';
 import DraftEditor from '../DraftEditor.react';
 import {createRoot, Root} from 'react-dom/client';
 import {flushSync} from 'react-dom';
+import {useDraftEditorBlockWindowing} from '../../hooks/useDraftEditorBlockWindowing';
+
+jest.mock('../../hooks/useDraftEditorBlockWindowing');
 
 let container: HTMLElement;
 let root: Root;
 let editorState: EditorState;
 
 beforeEach(() => {
+  jest.mocked(useDraftEditorBlockWindowing).mockReset().mockReturnValue(undefined);
   container = document.createElement('div');
   document.body.appendChild(container);
   root = createRoot(container);
   editorState = createEmpty();
+});
+
+test('owns block windowing lifecycle inputs', () => {
+  const editorRef = React.createRef<DraftEditor>();
+  const scrollContainerRef = {current: container};
+  const pinnedBlockKeys = new Set(['pinned']);
+
+  flushSync(() => {
+    root.render(
+      <DraftEditor
+        ref={editorRef}
+        editorState={editorState}
+        onChange={() => {}}
+        blockWindowing={{
+          enabled: true,
+          scrollContainerRef,
+          pinnedBlockKeys,
+        }}
+      />,
+    );
+  });
+
+  expect(useDraftEditorBlockWindowing).toHaveBeenLastCalledWith({
+    enabled: true,
+    editorState,
+    scrollContainerRef,
+    editorContainerRef: expect.objectContaining({
+      current: editorRef.current?.editorContainer,
+    }),
+    layoutKey: DraftEditor.defaultProps.blockStyleFn,
+    pinnedBlockKeys,
+  });
 });
 
 afterEach(() => {

--- a/src/component/contents/DraftEditorContents-core.react.tsx
+++ b/src/component/contents/DraftEditorContents-core.react.tsx
@@ -19,6 +19,7 @@ import {nullthrows} from '../../fbjs/nullthrows';
 import DraftOffsetKey from '../selection/DraftOffsetKey';
 import DraftEditorBlock from './DraftEditorBlock.react';
 import {BlockNode} from '../../model/immutable/BlockNode';
+import {DraftEditorBlockWindowing} from '../base/DraftEditorProps';
 import {
   DOMLocation,
   DOMSelectionUpdateFn,
@@ -30,6 +31,7 @@ type Props = {
   blockRenderMap: DraftBlockRenderMap;
   blockRendererFn: (block: BlockNode) => Record<string, any> | null;
   blockStyleFn?: (block: BlockNode) => string | CSSProperties | undefined;
+  blockWindowing?: DraftEditorBlockWindowing;
   customStyleFn?: (
     style: DraftInlineStyle,
     block: BlockNode,
@@ -128,6 +130,12 @@ export default class DraftEditorContents extends React.Component<Props> {
     const wasComposing = prevEditorState.inCompositionMode;
     const nowComposing = nextEditorState.inCompositionMode;
 
+    if (!(wasComposing && nowComposing)) {
+      if (this.props.blockWindowing !== nextProps.blockWindowing) {
+        return true;
+      }
+    }
+
     // If the state is unchanged or we're currently rendering a natively
     // rendered state, there's nothing new to be done.
     if (
@@ -190,6 +198,7 @@ export default class DraftEditorContents extends React.Component<Props> {
       blockRenderMap,
       blockRendererFn,
       blockStyleFn,
+      blockWindowing,
       customStyleMap,
       customStyleFn,
       editorState,
@@ -221,8 +230,57 @@ export default class DraftEditorContents extends React.Component<Props> {
       | ReactNode
       | undefined = undefined;
 
+    let spacerHeight = 0;
+    let spacerBlockLayout: Array<[number, number]> = [];
+    let spacerTextLength = 0;
+    let spacerStartKey: string | undefined;
+
+    const flushSpacer = () => {
+      if (spacerStartKey === undefined) {
+        return;
+      }
+      const key = `window-spacer-${spacerStartKey}`;
+      processedBlocks.push({
+        block: (
+          <div
+            aria-hidden="true"
+            contentEditable={false}
+            data-block-window-spacer="true"
+            data-block-window-spacer-layout={JSON.stringify(spacerBlockLayout)}
+            data-block-window-spacer-text-length={spacerTextLength}
+            key={key}
+            style={{height: spacerHeight, pointerEvents: 'none'}}
+          />
+        ),
+        wrapperTemplate: undefined,
+        key,
+        offsetKey: key,
+      });
+      spacerHeight = 0;
+      spacerBlockLayout = [];
+      spacerTextLength = 0;
+      spacerStartKey = undefined;
+      currentDepth = null;
+      lastWrapperTemplate = undefined;
+    };
+
     for (const block of content.blockMap.values()) {
       const key = block.key;
+
+      if (blockWindowing && !blockWindowing.shouldRenderBlock(block)) {
+        spacerStartKey = spacerStartKey || key;
+        const blockHeight = Math.max(
+          0,
+          blockWindowing.getSpacerHeight(block),
+        );
+        const blockTextLength = block.text.length + 1;
+        spacerHeight += blockHeight;
+        spacerBlockLayout.push([blockHeight, block.text.length]);
+        spacerTextLength += blockTextLength;
+        continue;
+      }
+
+      flushSpacer();
       const blockType = block.type;
 
       const customRenderer = blockRendererFn(block);
@@ -334,6 +392,8 @@ export default class DraftEditorContents extends React.Component<Props> {
       }
       lastWrapperTemplate = wrapperTemplate;
     }
+
+    flushSpacer();
 
     // Group contiguous runs of blocks that have the same wrapperTemplate
     const outputBlocks: ReactNode[] = [];

--- a/src/component/contents/DraftEditorContents-core.react.tsx
+++ b/src/component/contents/DraftEditorContents-core.react.tsx
@@ -234,6 +234,8 @@ export default class DraftEditorContents extends React.Component<Props> {
     let spacerBlockLayout: Array<[number, number]> = [];
     let spacerTextLength = 0;
     let spacerStartKey: string | undefined;
+    let spacerWrapperTemplate: (() => ReactNode) | ReactNode | undefined;
+    let SpacerElement = 'div';
 
     const flushSpacer = () => {
       if (spacerStartKey === undefined) {
@@ -241,18 +243,21 @@ export default class DraftEditorContents extends React.Component<Props> {
       }
       const key = `window-spacer-${spacerStartKey}`;
       processedBlocks.push({
-        block: (
-          <div
-            aria-hidden="true"
-            contentEditable={false}
-            data-block-window-spacer="true"
-            data-block-window-spacer-layout={JSON.stringify(spacerBlockLayout)}
-            data-block-window-spacer-text-length={spacerTextLength}
-            key={key}
-            style={{height: spacerHeight, pointerEvents: 'none'}}
-          />
-        ),
-        wrapperTemplate: undefined,
+        block: React.createElement(SpacerElement, {
+          'aria-hidden': true,
+          contentEditable: false,
+          'data-block-window-spacer': true,
+          'data-block-window-spacer-layout': JSON.stringify(spacerBlockLayout),
+          'data-block-window-spacer-text-length': spacerTextLength,
+          key,
+          style: {
+            display: 'block',
+            height: spacerHeight,
+            listStyle: 'none',
+            pointerEvents: 'none',
+          },
+        }),
+        wrapperTemplate: spacerWrapperTemplate,
         key,
         offsetKey: key,
       });
@@ -260,15 +265,34 @@ export default class DraftEditorContents extends React.Component<Props> {
       spacerBlockLayout = [];
       spacerTextLength = 0;
       spacerStartKey = undefined;
+      spacerWrapperTemplate = undefined;
+      SpacerElement = 'div';
       currentDepth = null;
       lastWrapperTemplate = undefined;
     };
 
     for (const block of content.blockMap.values()) {
       const key = block.key;
+      const blockType = block.type;
+      const configForType =
+        blockRenderMap[blockType] || blockRenderMap['unstyled'];
+      const wrapperTemplate: (() => ReactNode) | ReactNode | undefined =
+        configForType.wrapper;
+      const Element =
+        configForType.element || blockRenderMap['unstyled'].element;
 
       if (blockWindowing && !blockWindowing.shouldRenderBlock(block)) {
+        const nextSpacerElement = wrapperTemplate ? Element : 'div';
+        if (
+          spacerStartKey !== undefined &&
+          (spacerWrapperTemplate !== wrapperTemplate ||
+            SpacerElement !== nextSpacerElement)
+        ) {
+          flushSpacer();
+        }
         spacerStartKey = spacerStartKey || key;
+        spacerWrapperTemplate = wrapperTemplate;
+        SpacerElement = nextSpacerElement;
         const blockHeight = Math.max(
           0,
           blockWindowing.getSpacerHeight(block),
@@ -281,7 +305,6 @@ export default class DraftEditorContents extends React.Component<Props> {
       }
 
       flushSpacer();
-      const blockType = block.type;
 
       const customRenderer = blockRendererFn(block);
       let CustomComponent, customProps, customEditable;
@@ -317,14 +340,6 @@ export default class DraftEditorContents extends React.Component<Props> {
           ? this.scheduleDomSelectionUpdate
           : undefined,
       };
-
-      const configForType =
-        blockRenderMap[blockType] || blockRenderMap['unstyled'];
-      const wrapperTemplate: (() => ReactNode) | ReactNode | undefined =
-        configForType.wrapper;
-
-      const Element =
-        configForType.element || blockRenderMap['unstyled'].element;
 
       const depth = block.depth;
       let className = '';

--- a/src/component/contents/DraftEditorContents-core.react.tsx
+++ b/src/component/contents/DraftEditorContents-core.react.tsx
@@ -19,7 +19,7 @@ import {nullthrows} from '../../fbjs/nullthrows';
 import DraftOffsetKey from '../selection/DraftOffsetKey';
 import DraftEditorBlock from './DraftEditorBlock.react';
 import {BlockNode} from '../../model/immutable/BlockNode';
-import {DraftEditorBlockWindowing} from '../base/DraftEditorProps';
+import {DraftEditorBlockWindowingState} from '../hooks/useDraftEditorBlockWindowing';
 import {
   DOMLocation,
   DOMSelectionUpdateFn,
@@ -31,7 +31,7 @@ type Props = {
   blockRenderMap: DraftBlockRenderMap;
   blockRendererFn: (block: BlockNode) => Record<string, any> | null;
   blockStyleFn?: (block: BlockNode) => string | CSSProperties | undefined;
-  blockWindowing?: DraftEditorBlockWindowing;
+  blockWindowing?: DraftEditorBlockWindowingState;
   customStyleFn?: (
     style: DraftInlineStyle,
     block: BlockNode,

--- a/src/component/contents/DraftEditorWindowedContents.react.tsx
+++ b/src/component/contents/DraftEditorWindowedContents.react.tsx
@@ -1,0 +1,35 @@
+import React, {RefObject} from 'react';
+import {DraftEditorBlockWindowingOptions} from '../base/DraftEditorProps';
+import DraftEditorContents from './DraftEditorContents-core.react';
+import {useDraftEditorBlockWindowing} from '../hooks/useDraftEditorBlockWindowing';
+
+type Props = Omit<React.ComponentProps<typeof DraftEditorContents>, 'blockWindowing'> & {
+  blockWindowing?: DraftEditorBlockWindowingOptions;
+  contentsKey: number;
+  editorContainerRef: RefObject<HTMLElement>;
+};
+
+export default function DraftEditorWindowedContents({
+  blockWindowing,
+  contentsKey,
+  editorContainerRef,
+  ...contentsProps
+}: Props): React.ReactNode {
+  const resolvedBlockWindowing = useDraftEditorBlockWindowing({
+    enabled: blockWindowing?.enabled ?? false,
+    editorState: contentsProps.editorState,
+    scrollContainerRef:
+      blockWindowing?.scrollContainerRef ?? editorContainerRef,
+    editorContainerRef,
+    layoutKey: contentsProps.blockStyleFn,
+    pinnedBlockKeys: blockWindowing?.pinnedBlockKeys,
+  });
+
+  return (
+    <DraftEditorContents
+      {...contentsProps}
+      blockWindowing={resolvedBlockWindowing}
+      key={'contents' + contentsKey}
+    />
+  );
+}

--- a/src/component/contents/__tests__/DraftEditorContents.react-test.tsx
+++ b/src/component/contents/__tests__/DraftEditorContents.react-test.tsx
@@ -8,7 +8,12 @@
  * @format
  */
 
-import {createEmpty, EditorState} from '../../../model/immutable/EditorState';
+import {
+  createEmpty,
+  createWithContent,
+  EditorState,
+} from '../../../model/immutable/EditorState';
+import {createFromText} from '../../../model/immutable/ContentState';
 
 import React from 'react';
 import RichTextEditorUtil from '../../../model/modifier/RichTextEditorUtil';
@@ -109,4 +114,43 @@ test('defaults to "unstyled" block type for unknown block types', () => {
   expect(() => {
     editorInstance?.toggleCustomBlock();
   }).not.toThrow();
+});
+
+test('renders windowed blocks and replaces omitted runs with spacers', () => {
+  const editorState = createWithContent(createFromText('zero\none\ntwo\nthree'));
+  const blocks = Array.from(editorState.currentContent.blockMap.values());
+  const blockRendererFn = jest.fn(() => null);
+
+  flushSync(() => {
+    root.render(
+      <DraftEditor
+        editorState={editorState}
+        onChange={() => {}}
+        blockRendererFn={blockRendererFn}
+        blockWindowing={{
+          shouldRenderBlock: block => block === blocks[1] || block === blocks[3],
+          getSpacerHeight: block => (blocks.indexOf(block) + 1) * 10,
+        }}
+      />,
+    );
+  });
+
+  expect(Array.from(container.querySelectorAll('[data-block]'))).toHaveLength(2);
+  expect(blockRendererFn).toHaveBeenCalledTimes(2);
+  expect(
+    Array.from(
+      container.querySelectorAll<HTMLElement>('[data-block-window-spacer]'),
+    ).map(spacer => spacer.style.height),
+  ).toEqual(['10px', '30px']);
+  expect(
+    Array.from(
+      container.querySelectorAll<HTMLElement>('[data-block-window-spacer]'),
+    ).map(spacer => spacer.dataset.blockWindowSpacerTextLength),
+  ).toEqual(['5', '4']);
+  expect(
+    Array.from(
+      container.querySelectorAll<HTMLElement>('[data-block-window-spacer]'),
+    ).map(spacer => spacer.dataset.blockWindowSpacerLayout),
+  ).toEqual(['[[10,4]]', '[[30,3]]']);
+  expect(container.textContent).toBe('onethree');
 });

--- a/src/component/contents/__tests__/DraftEditorContents.react-test.tsx
+++ b/src/component/contents/__tests__/DraftEditorContents.react-test.tsx
@@ -20,6 +20,8 @@ import RichTextEditorUtil from '../../../model/modifier/RichTextEditorUtil';
 import {createRoot, Root} from 'react-dom/client';
 import {flushSync} from 'react-dom';
 import DraftEditor from '../../base/DraftEditor.react';
+import DraftEditorContents from '../DraftEditorContents-core.react';
+import {DefaultDraftBlockRenderMap} from '../../../model/immutable/DefaultDraftBlockRenderMap';
 
 let container: HTMLElement;
 let root: Root;
@@ -123,9 +125,9 @@ test('renders windowed blocks and replaces omitted runs with spacers', () => {
 
   flushSync(() => {
     root.render(
-      <DraftEditor
+      <DraftEditorContents
         editorState={editorState}
-        onChange={() => {}}
+        blockRenderMap={DefaultDraftBlockRenderMap}
         blockRendererFn={blockRendererFn}
         blockWindowing={{
           shouldRenderBlock: block => block === blocks[1] || block === blocks[3],
@@ -164,9 +166,9 @@ test('keeps windowed spacers in the same custom block wrapper', () => {
 
   flushSync(() => {
     root.render(
-      <DraftEditor
+      <DraftEditorContents
         editorState={editorState}
-        onChange={() => {}}
+        blockRendererFn={() => null}
         blockRenderMap={{
           unstyled: {
             element: 'div',

--- a/src/component/contents/__tests__/DraftEditorContents.react-test.tsx
+++ b/src/component/contents/__tests__/DraftEditorContents.react-test.tsx
@@ -154,3 +154,37 @@ test('renders windowed blocks and replaces omitted runs with spacers', () => {
   ).toEqual(['[[10,4]]', '[[30,3]]']);
   expect(container.textContent).toBe('onethree');
 });
+
+test('keeps windowed spacers in the same custom block wrapper', () => {
+  const editorState = createWithContent(createFromText('zero\none\ntwo'));
+  const blocks = Array.from(editorState.currentContent.blockMap.values());
+  const wrapper = (
+    <div data-testid="fixed-height-wrapper" style={{height: 200}} />
+  );
+
+  flushSync(() => {
+    root.render(
+      <DraftEditor
+        editorState={editorState}
+        onChange={() => {}}
+        blockRenderMap={{
+          unstyled: {
+            element: 'div',
+            wrapper,
+          },
+        }}
+        blockWindowing={{
+          shouldRenderBlock: block => block !== blocks[1],
+          getSpacerHeight: () => 40,
+        }}
+      />,
+    );
+  });
+
+  const wrappers = container.querySelectorAll('[data-testid="fixed-height-wrapper"]');
+  expect(wrappers).toHaveLength(1);
+  expect(wrappers[0]?.children).toHaveLength(3);
+  expect(
+    wrappers[0]?.querySelector<HTMLElement>('[data-block-window-spacer]')?.style.height,
+  ).toBe('40px');
+});

--- a/src/component/contents/__tests__/getDraftEditorWindowedTextOffset-test.ts
+++ b/src/component/contents/__tests__/getDraftEditorWindowedTextOffset-test.ts
@@ -1,12 +1,3 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- * @format
- */
-
 import {createFromText} from '../../../model/immutable/ContentState';
 import {getDraftEditorWindowedTextOffset} from '../getDraftEditorWindowedTextOffset';
 

--- a/src/component/contents/__tests__/getDraftEditorWindowedTextOffset-test.ts
+++ b/src/component/contents/__tests__/getDraftEditorWindowedTextOffset-test.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import {createFromText} from '../../../model/immutable/ContentState';
+import {getDraftEditorWindowedTextOffset} from '../getDraftEditorWindowedTextOffset';
+
+function createRect({y, height}: {y: number; height: number}): DOMRect {
+  return {
+    x: 0,
+    y,
+    width: 0,
+    height,
+    top: y,
+    right: 0,
+    bottom: y + height,
+    left: 0,
+    toJSON: () => ({}),
+  };
+}
+
+describe('getDraftEditorWindowedTextOffset', () => {
+  test('includes text represented by block window spacers', () => {
+    const contentState = createFromText('zero\none\ntwo');
+    const [, secondBlock, thirdBlock] = Array.from(contentState.blockMap.values());
+    const contentsElement = document.createElement('div');
+    const spacer = document.createElement('div');
+    spacer.dataset.blockWindowSpacer = 'true';
+    spacer.dataset.blockWindowSpacerLayout = '[[100,4]]';
+    spacer.dataset.blockWindowSpacerTextLength = '5';
+    const secondElement = document.createElement('div');
+    secondElement.dataset.block = 'true';
+    secondElement.id = `block-${secondBlock?.key}`;
+    const thirdElement = document.createElement('div');
+    thirdElement.dataset.block = 'true';
+    thirdElement.id = `block-${thirdBlock?.key}`;
+    contentsElement.append(spacer, secondElement, thirdElement);
+
+    jest
+      .spyOn(spacer, 'getBoundingClientRect')
+      .mockReturnValue(createRect({y: -100, height: 100}));
+    jest
+      .spyOn(secondElement, 'getBoundingClientRect')
+      .mockReturnValue(createRect({y: 0, height: 50}));
+    jest
+      .spyOn(thirdElement, 'getBoundingClientRect')
+      .mockReturnValue(createRect({y: 50, height: 50}));
+
+    expect(
+      getDraftEditorWindowedTextOffset(contentState, contentsElement, 0, 75),
+    ).toBe(11);
+  });
+
+  test('uses individual block heights within a window spacer', () => {
+    const contentState = createFromText(`${'x'.repeat(100)}\nyyyy\ntwo`);
+    const contentsElement = document.createElement('div');
+    const spacer = document.createElement('div');
+    spacer.dataset.blockWindowSpacer = 'true';
+    spacer.dataset.blockWindowSpacerLayout = '[[90,100],[10,4]]';
+    spacer.dataset.blockWindowSpacerTextLength = '106';
+    contentsElement.append(spacer);
+    jest
+      .spyOn(spacer, 'getBoundingClientRect')
+      .mockReturnValue(createRect({y: -100, height: 100}));
+
+    expect(
+      getDraftEditorWindowedTextOffset(contentState, contentsElement, -55, 50),
+    ).toBe(103);
+  });
+
+  test('returns undefined when the editor is not windowed', () => {
+    expect(
+      getDraftEditorWindowedTextOffset(
+        createFromText('zero'),
+        document.createElement('div'),
+        0,
+        100,
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/src/component/contents/__tests__/getDraftEditorWindowedTextOffset-test.ts
+++ b/src/component/contents/__tests__/getDraftEditorWindowedTextOffset-test.ts
@@ -1,5 +1,8 @@
 import {createFromText} from '../../../model/immutable/ContentState';
-import {getDraftEditorWindowedTextOffset} from '../getDraftEditorWindowedTextOffset';
+import {
+  getDraftEditorBlockKeyForTextOffset,
+  getDraftEditorWindowedTextOffset,
+} from '../getDraftEditorWindowedTextOffset';
 
 function createRect({y, height}: {y: number; height: number}): DOMRect {
   return {
@@ -73,5 +76,17 @@ describe('getDraftEditorWindowedTextOffset', () => {
         100,
       ),
     ).toBeUndefined();
+  });
+});
+
+describe('getDraftEditorBlockKeyForTextOffset', () => {
+  test('maps block text and newline offsets to block keys', () => {
+    const contentState = createFromText('zero\none\ntwo');
+    const [first, second, third] = Array.from(contentState.blockMap.values());
+
+    expect(getDraftEditorBlockKeyForTextOffset(contentState, 4)).toBe(first?.key);
+    expect(getDraftEditorBlockKeyForTextOffset(contentState, 5)).toBe(second?.key);
+    expect(getDraftEditorBlockKeyForTextOffset(contentState, 9)).toBe(third?.key);
+    expect(getDraftEditorBlockKeyForTextOffset(contentState, 100)).toBe(third?.key);
   });
 });

--- a/src/component/contents/getDraftEditorWindowedTextOffset.ts
+++ b/src/component/contents/getDraftEditorWindowedTextOffset.ts
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import {ContentState} from '../../model/immutable/ContentState';
+
+function getTextLengthWithinWindowSpacer(
+  element: HTMLElement,
+  visibleHeight: number,
+  spacerTextLength: number,
+): number {
+  const encodedLayout = element.dataset.blockWindowSpacerLayout;
+  if (encodedLayout) {
+    let parsedLayout: unknown;
+    try {
+      parsedLayout = JSON.parse(encodedLayout);
+    } catch {
+      parsedLayout = undefined;
+    }
+    if (Array.isArray(parsedLayout)) {
+      let remainingHeight = visibleHeight;
+      let textLength = 0;
+      for (const entry of parsedLayout) {
+        if (
+          !Array.isArray(entry) ||
+          typeof entry[0] !== 'number' ||
+          typeof entry[1] !== 'number'
+        ) {
+          continue;
+        }
+        const [blockHeight, blockTextLength] = entry;
+        if (remainingHeight >= blockHeight) {
+          textLength += blockTextLength + 1;
+          remainingHeight -= blockHeight;
+          continue;
+        }
+        if (blockHeight > 0) {
+          textLength += Math.round(
+            blockTextLength * Math.max(0, remainingHeight / blockHeight),
+          );
+        }
+        return textLength;
+      }
+      return textLength;
+    }
+  }
+
+  const spacerHeight = element.getBoundingClientRect().height;
+  return spacerHeight > 0
+    ? Math.round(
+        spacerTextLength * Math.max(0, visibleHeight / spacerHeight),
+      )
+    : spacerTextLength;
+}
+
+export function getDraftEditorWindowedTextOffset(
+  contentState: ContentState,
+  contentsElement: HTMLElement,
+  targetY: number,
+  viewportHeight: number,
+): number | undefined {
+  const windowSpacers = contentsElement.querySelectorAll<HTMLElement>(
+    '[data-block-window-spacer]',
+  );
+  if (windowSpacers.length === 0) {
+    return undefined;
+  }
+
+  const targetBottom = targetY + viewportHeight;
+  let textOffset = 0;
+  const layoutElements = contentsElement.querySelectorAll<HTMLElement>(
+    '[data-block], [data-block-window-spacer]',
+  );
+  for (const element of layoutElements) {
+    const rect = element.getBoundingClientRect();
+    if (rect.top >= targetBottom) {
+      break;
+    }
+
+    const spacerTextLength = Number(
+      element.dataset.blockWindowSpacerTextLength,
+    );
+    const blockKey = element.id.startsWith('block-')
+      ? element.id.slice('block-'.length)
+      : undefined;
+    const block = blockKey ? contentState.blockMap.get(blockKey) : undefined;
+    const textLength = Number.isFinite(spacerTextLength)
+      ? spacerTextLength
+      : block
+      ? block.text.length + 1
+      : 0;
+    if (rect.bottom <= targetBottom || rect.height === 0) {
+      textOffset += textLength;
+      continue;
+    }
+
+    const visibleHeight = targetBottom - rect.top;
+    if (Number.isFinite(spacerTextLength)) {
+      textOffset += getTextLengthWithinWindowSpacer(
+        element,
+        visibleHeight,
+        spacerTextLength,
+      );
+    } else if (block) {
+      const visibleRatio = Math.max(
+        0,
+        Math.min(1, visibleHeight / rect.height),
+      );
+      textOffset += Math.round(block.text.length * visibleRatio);
+    }
+    break;
+  }
+  return textOffset;
+}

--- a/src/component/contents/getDraftEditorWindowedTextOffset.ts
+++ b/src/component/contents/getDraftEditorWindowedTextOffset.ts
@@ -1,12 +1,3 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- * @format
- */
-
 import {ContentState} from '../../model/immutable/ContentState';
 
 function getTextLengthWithinWindowSpacer(

--- a/src/component/contents/getDraftEditorWindowedTextOffset.ts
+++ b/src/component/contents/getDraftEditorWindowedTextOffset.ts
@@ -1,5 +1,21 @@
 import {ContentState} from '../../model/immutable/ContentState';
 
+export function getDraftEditorBlockKeyForTextOffset(
+  contentState: ContentState,
+  textOffset: number,
+): string | undefined {
+  let remainingOffset = Math.max(0, textOffset);
+  let lastBlockKey: string | undefined;
+  for (const block of contentState.blockMap.values()) {
+    lastBlockKey = block.key;
+    if (remainingOffset <= block.text.length) {
+      return block.key;
+    }
+    remainingOffset -= block.text.length + 1;
+  }
+  return lastBlockKey;
+}
+
 function getTextLengthWithinWindowSpacer(
   element: HTMLElement,
   visibleHeight: number,

--- a/src/component/hooks/__tests__/useDraftEditorBlockWindowing-test.ts
+++ b/src/component/hooks/__tests__/useDraftEditorBlockWindowing-test.ts
@@ -162,9 +162,11 @@ test('keeps selection endpoints and external pinned blocks rendered', async () =
     }
   };
 
-  let blockWindowing: ReturnType<typeof useDraftEditorBlockWindowing> = undefined;
+  const blockWindowing: {
+    current: ReturnType<typeof useDraftEditorBlockWindowing>;
+  } = {current: undefined};
   function Harness({state}: {state: typeof editorState}) {
-    blockWindowing = useDraftEditorBlockWindowing({
+    blockWindowing.current = useDraftEditorBlockWindowing({
       enabled: true,
       editorState: state,
       scrollContainerRef: {current: scrollContainer},
@@ -184,11 +186,11 @@ test('keeps selection endpoints and external pinned blocks rendered', async () =
     ),
   );
 
-  expect(blockWindowing).toBeDefined();
-  expect(blockWindowing?.shouldRenderBlock(blocks[20]!)).toBe(true);
-  expect(blockWindowing?.shouldRenderBlock(blocks[28]!)).toBe(true);
-  expect(blockWindowing?.shouldRenderBlock(blocks[29]!)).toBe(true);
-  expect(blockWindowing?.shouldRenderBlock(blocks[21]!)).toBe(false);
+  expect(blockWindowing.current).toBeDefined();
+  expect(blockWindowing.current?.shouldRenderBlock(blocks[20]!)).toBe(true);
+  expect(blockWindowing.current?.shouldRenderBlock(blocks[28]!)).toBe(true);
+  expect(blockWindowing.current?.shouldRenderBlock(blocks[29]!)).toBe(true);
+  expect(blockWindowing.current?.shouldRenderBlock(blocks[21]!)).toBe(false);
 
   const splitSelection = makeSelectionState({
     anchorKey: blocks[20]!.key,
@@ -213,9 +215,11 @@ test('keeps selection endpoints and external pinned blocks rendered', async () =
     ),
   );
 
-  expect(blockWindowing).toBeDefined();
+  expect(blockWindowing.current).toBeDefined();
   expect(
-    blocksAfterSplit.filter(block => blockWindowing?.shouldRenderBlock(block)),
+    blocksAfterSplit.filter(block =>
+      blockWindowing.current?.shouldRenderBlock(block),
+    ),
   ).not.toHaveLength(blocksAfterSplit.length);
 
   await act(async () => root.unmount());

--- a/src/component/hooks/__tests__/useDraftEditorBlockWindowing-test.ts
+++ b/src/component/hooks/__tests__/useDraftEditorBlockWindowing-test.ts
@@ -1,12 +1,3 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- * @format
- */
-
 import {exportedForTesting} from '../useDraftEditorBlockWindowing';
 
 const {getWindowRange} = exportedForTesting;

--- a/src/component/hooks/__tests__/useDraftEditorBlockWindowing-test.ts
+++ b/src/component/hooks/__tests__/useDraftEditorBlockWindowing-test.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import {exportedForTesting} from '../useDraftEditorBlockWindowing';
+
+const {getWindowRange} = exportedForTesting;
+
+describe('getWindowRange', () => {
+  const blockLayout = {
+    keys: ['a', 'b', 'c'],
+    offsets: [0, 10, 30],
+    heights: new Map([
+      ['a', 10],
+      ['b', 20],
+      ['c', 30],
+    ]),
+  };
+
+  test('returns blocks intersecting the viewport', () => {
+    expect(getWindowRange(blockLayout, 11, 29)).toEqual({start: 1, end: 2});
+  });
+
+  test('includes blocks touching either viewport boundary', () => {
+    expect(getWindowRange(blockLayout, 10, 30)).toEqual({start: 0, end: 3});
+  });
+
+  test('handles a viewport after the content', () => {
+    expect(getWindowRange(blockLayout, 100, 120)).toEqual({start: 3, end: 3});
+  });
+});

--- a/src/component/hooks/__tests__/useDraftEditorBlockWindowing-test.ts
+++ b/src/component/hooks/__tests__/useDraftEditorBlockWindowing-test.ts
@@ -1,6 +1,17 @@
-import {exportedForTesting} from '../useDraftEditorBlockWindowing';
+import React, {act} from 'react';
+import {createRoot} from 'react-dom/client';
+import {
+  createWithContent,
+  forceSelection,
+} from '../../../model/immutable/EditorState';
+import {createFromText} from '../../../model/immutable/ContentState';
+import {makeSelectionState} from '../../../model/immutable/SelectionState';
+import {
+  exportedForTesting,
+  useDraftEditorBlockWindowing,
+} from '../useDraftEditorBlockWindowing';
 
-const {getWindowRange} = exportedForTesting;
+const {getWindowRange, haveEqualLayout} = exportedForTesting;
 
 describe('getWindowRange', () => {
   const blockLayout = {
@@ -24,4 +35,129 @@ describe('getWindowRange', () => {
   test('handles a viewport after the content', () => {
     expect(getWindowRange(blockLayout, 100, 120)).toEqual({start: 3, end: 3});
   });
+});
+
+describe('haveEqualLayout', () => {
+  const block = {key: 'a'} as any;
+
+  test('ignores block identity changes when ordered heights are unchanged', () => {
+    expect(
+      haveEqualLayout(
+        new Map([['a', {block, height: 10}]]),
+        new Map([['a', {block: {...block}, height: 10}]]),
+      ),
+    ).toBe(true);
+  });
+
+  test('detects height and block order changes', () => {
+    const previous = new Map([
+      ['a', {block, height: 10}],
+      ['b', {block, height: 20}],
+    ]);
+    expect(
+      haveEqualLayout(
+        previous,
+        new Map([
+          ['a', {block, height: 11}],
+          ['b', {block, height: 20}],
+        ]),
+      ),
+    ).toBe(false);
+    expect(
+      haveEqualLayout(
+        previous,
+        new Map([
+          ['b', {block, height: 20}],
+          ['a', {block, height: 10}],
+        ]),
+      ),
+    ).toBe(false);
+  });
+});
+
+test('keeps selection endpoints and external pinned blocks rendered', async () => {
+  const reactActEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+  const previousReactActEnvironment = reactActEnvironment.IS_REACT_ACT_ENVIRONMENT;
+  reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  const contentState = createFromText(
+    Array.from({length: 30}, (_, index) => `block ${index}`).join('\n'),
+  );
+  const blocks = Array.from(contentState.blockMap.values());
+  const editorState = forceSelection(
+    createWithContent(contentState),
+    makeSelectionState({
+      anchorKey: blocks[28]!.key,
+      focusKey: blocks[29]!.key,
+    }),
+  );
+  const scrollContainer = document.createElement('div');
+  const editorContainer = document.createElement('div');
+  const contents = document.createElement('div');
+  contents.dataset.contents = 'true';
+  editorContainer.append(contents);
+  document.body.append(scrollContainer, editorContainer);
+  Object.defineProperty(scrollContainer, 'clientHeight', {value: 100});
+  scrollContainer.getBoundingClientRect = () =>
+    ({top: 0, bottom: 100, height: 100} as DOMRect);
+  contents.getBoundingClientRect = () =>
+    ({top: 0, bottom: 3000, height: 3000} as DOMRect);
+  for (const [index, block] of blocks.entries()) {
+    const element = document.createElement('div');
+    element.id = `block-${block.key}`;
+    element.getBoundingClientRect = () =>
+      ({
+        top: index * 100,
+        bottom: (index + 1) * 100,
+        height: 100,
+      }) as DOMRect;
+    contents.append(element);
+  }
+
+  let animationFrameId = 0;
+  const animationFrames = new Map<number, FrameRequestCallback>();
+  jest.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+    animationFrameId += 1;
+    animationFrames.set(animationFrameId, callback);
+    return animationFrameId;
+  });
+  jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(id => {
+    animationFrames.delete(id);
+  });
+  const flushAnimationFrames = () => {
+    const callbacks = Array.from(animationFrames.values());
+    animationFrames.clear();
+    for (const callback of callbacks) {
+      callback(performance.now());
+    }
+  };
+
+  let blockWindowing: ReturnType<typeof useDraftEditorBlockWindowing> = undefined;
+  function Harness() {
+    blockWindowing = useDraftEditorBlockWindowing({
+      enabled: true,
+      editorState,
+      scrollContainerRef: {current: scrollContainer},
+      editorContainerRef: {current: editorContainer},
+      pinnedBlockKeys: new Set([blocks[20]!.key]),
+    });
+    return null;
+  }
+
+  const root = createRoot(document.createElement('div'));
+  await act(async () => root.render(React.createElement(Harness)));
+  await act(async () => flushAnimationFrames());
+
+  expect(blockWindowing).toBeDefined();
+  expect(blockWindowing?.shouldRenderBlock(blocks[20]!)).toBe(true);
+  expect(blockWindowing?.shouldRenderBlock(blocks[28]!)).toBe(true);
+  expect(blockWindowing?.shouldRenderBlock(blocks[29]!)).toBe(true);
+  expect(blockWindowing?.shouldRenderBlock(blocks[21]!)).toBe(false);
+
+  await act(async () => root.unmount());
+  scrollContainer.remove();
+  editorContainer.remove();
+  jest.restoreAllMocks();
+  reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = previousReactActEnvironment;
 });

--- a/src/component/hooks/__tests__/useDraftEditorBlockWindowing-test.ts
+++ b/src/component/hooks/__tests__/useDraftEditorBlockWindowing-test.ts
@@ -3,15 +3,17 @@ import {createRoot} from 'react-dom/client';
 import {
   createWithContent,
   forceSelection,
+  pushContent,
 } from '../../../model/immutable/EditorState';
 import {createFromText} from '../../../model/immutable/ContentState';
 import {makeSelectionState} from '../../../model/immutable/SelectionState';
+import DraftModifier from '../../../model/modifier/DraftModifier';
 import {
   exportedForTesting,
   useDraftEditorBlockWindowing,
 } from '../useDraftEditorBlockWindowing';
 
-const {getWindowRange, haveEqualLayout} = exportedForTesting;
+const {getBlockLayout, getWindowRange, haveEqualLayout} = exportedForTesting;
 
 describe('getWindowRange', () => {
   const blockLayout = {
@@ -38,28 +40,26 @@ describe('getWindowRange', () => {
 });
 
 describe('haveEqualLayout', () => {
-  const block = {key: 'a'} as any;
-
-  test('ignores block identity changes when ordered heights are unchanged', () => {
+  test('preserves layout identity when ordered heights are unchanged', () => {
     expect(
       haveEqualLayout(
-        new Map([['a', {block, height: 10}]]),
-        new Map([['a', {block: {...block}, height: 10}]]),
+        new Map([['a', {height: 10}]]),
+        new Map([['a', {height: 10}]]),
       ),
     ).toBe(true);
   });
 
   test('detects height and block order changes', () => {
     const previous = new Map([
-      ['a', {block, height: 10}],
-      ['b', {block, height: 20}],
+      ['a', {height: 10}],
+      ['b', {height: 20}],
     ]);
     expect(
       haveEqualLayout(
         previous,
         new Map([
-          ['a', {block, height: 11}],
-          ['b', {block, height: 20}],
+          ['a', {height: 11}],
+          ['b', {height: 20}],
         ]),
       ),
     ).toBe(false);
@@ -67,12 +67,28 @@ describe('haveEqualLayout', () => {
       haveEqualLayout(
         previous,
         new Map([
-          ['b', {block, height: 20}],
-          ['a', {block, height: 10}],
+          ['b', {height: 20}],
+          ['a', {height: 10}],
         ]),
       ),
     ).toBe(false);
   });
+});
+
+test('estimates new block heights without discarding the measured layout', () => {
+  const contentState = createFromText('zero\none\ntwo');
+  const blocks = Array.from(contentState.blockMap.values());
+  const layout = getBlockLayout(
+    contentState.blockMap,
+    new Map([
+      [blocks[0]!.key, {height: 20}],
+      [blocks[2]!.key, {height: 40}],
+    ]),
+  );
+
+  expect(layout?.keys).toEqual(blocks.map(block => block.key));
+  expect(layout?.heights.get(blocks[1]!.key)).toBe(30);
+  expect(layout?.offsets).toEqual([0, 20, 50]);
 });
 
 test('keeps selection endpoints and external pinned blocks rendered', async () => {
@@ -103,6 +119,8 @@ test('keeps selection endpoints and external pinned blocks rendered', async () =
     ({top: 0, bottom: 100, height: 100} as DOMRect);
   contents.getBoundingClientRect = () =>
     ({top: 0, bottom: 3000, height: 3000} as DOMRect);
+  editorContainer.getBoundingClientRect = () =>
+    ({width: 500, height: 3000} as DOMRect);
   for (const [index, block] of blocks.entries()) {
     const element = document.createElement('div');
     element.id = `block-${block.key}`;
@@ -125,6 +143,17 @@ test('keeps selection endpoints and external pinned blocks rendered', async () =
   jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(id => {
     animationFrames.delete(id);
   });
+  let resizeCallback: ResizeObserverCallback | undefined;
+  const originalResizeObserver = globalThis.ResizeObserver;
+  const resizeObserver = {
+    disconnect: jest.fn(),
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+  };
+  globalThis.ResizeObserver = jest.fn(callback => {
+    resizeCallback = callback;
+    return resizeObserver;
+  }) as unknown as typeof ResizeObserver;
   const flushAnimationFrames = () => {
     const callbacks = Array.from(animationFrames.values());
     animationFrames.clear();
@@ -134,10 +163,10 @@ test('keeps selection endpoints and external pinned blocks rendered', async () =
   };
 
   let blockWindowing: ReturnType<typeof useDraftEditorBlockWindowing> = undefined;
-  function Harness() {
+  function Harness({state}: {state: typeof editorState}) {
     blockWindowing = useDraftEditorBlockWindowing({
       enabled: true,
-      editorState,
+      editorState: state,
       scrollContainerRef: {current: scrollContainer},
       editorContainerRef: {current: editorContainer},
       pinnedBlockKeys: new Set([blocks[20]!.key]),
@@ -146,8 +175,14 @@ test('keeps selection endpoints and external pinned blocks rendered', async () =
   }
 
   const root = createRoot(document.createElement('div'));
-  await act(async () => root.render(React.createElement(Harness)));
+  await act(async () => root.render(React.createElement(Harness, {state: editorState})));
   await act(async () => flushAnimationFrames());
+  await act(async () =>
+    resizeCallback?.(
+      [{contentRect: {width: 500, height: 3000}} as ResizeObserverEntry],
+      resizeObserver as unknown as ResizeObserver,
+    ),
+  );
 
   expect(blockWindowing).toBeDefined();
   expect(blockWindowing?.shouldRenderBlock(blocks[20]!)).toBe(true);
@@ -155,9 +190,38 @@ test('keeps selection endpoints and external pinned blocks rendered', async () =
   expect(blockWindowing?.shouldRenderBlock(blocks[29]!)).toBe(true);
   expect(blockWindowing?.shouldRenderBlock(blocks[21]!)).toBe(false);
 
+  const splitSelection = makeSelectionState({
+    anchorKey: blocks[20]!.key,
+    anchorOffset: 3,
+    focusKey: blocks[20]!.key,
+    focusOffset: 3,
+  });
+  const beforeSplit = forceSelection(editorState, splitSelection);
+  const afterSplit = pushContent(
+    beforeSplit,
+    DraftModifier.splitBlock(beforeSplit.currentContent, splitSelection),
+    'split-block',
+  );
+  const blocksAfterSplit = Array.from(afterSplit.currentContent.blockMap.values());
+  await act(async () =>
+    root.render(React.createElement(Harness, {state: afterSplit})),
+  );
+  await act(async () =>
+    resizeCallback?.(
+      [{contentRect: {width: 500, height: 3100}} as ResizeObserverEntry],
+      resizeObserver as unknown as ResizeObserver,
+    ),
+  );
+
+  expect(blockWindowing).toBeDefined();
+  expect(
+    blocksAfterSplit.filter(block => blockWindowing?.shouldRenderBlock(block)),
+  ).not.toHaveLength(blocksAfterSplit.length);
+
   await act(async () => root.unmount());
   scrollContainer.remove();
   editorContainer.remove();
   jest.restoreAllMocks();
+  globalThis.ResizeObserver = originalResizeObserver;
   reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = previousReactActEnvironment;
 });

--- a/src/component/hooks/useDraftEditorBlockWindowing.ts
+++ b/src/component/hooks/useDraftEditorBlockWindowing.ts
@@ -28,7 +28,29 @@ export type DraftEditorBlockWindowingOptions = {
   scrollContainerRef: RefObject<HTMLElement>;
   editorContainerRef: RefObject<HTMLElement>;
   layoutKey?: unknown;
+  pinnedBlockKeys?: ReadonlySet<string>;
 };
+
+function haveEqualLayout(
+  previous: ReadonlyMap<string, BlockMeasurement>,
+  next: ReadonlyMap<string, BlockMeasurement>,
+): boolean {
+  if (previous.size !== next.size) {
+    return false;
+  }
+  const previousEntries = previous.entries();
+  for (const [nextKey, nextMeasurement] of next) {
+    const previousEntry = previousEntries.next();
+    if (
+      previousEntry.done ||
+      previousEntry.value[0] !== nextKey ||
+      previousEntry.value[1].height !== nextMeasurement.height
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
 
 function getWindowRange(
   blockLayout: BlockLayout,
@@ -94,6 +116,7 @@ export function useDraftEditorBlockWindowing({
   scrollContainerRef,
   editorContainerRef,
   layoutKey,
+  pinnedBlockKeys,
 }: DraftEditorBlockWindowingOptions): DraftEditorBlockWindowing | undefined {
   const blockMap = editorState.currentContent.blockMap;
   const measurementsRef = useRef<ReadonlyMap<string, BlockMeasurement>>(new Map());
@@ -107,7 +130,11 @@ export function useDraftEditorBlockWindowing({
   const updateMeasurements = useCallback(() => {
     const nextMeasurements = measureBlocks(blockMap, measurementsRef.current);
     measurementsRef.current = nextMeasurements;
-    setMeasurements(nextMeasurements);
+    setMeasurements(previousMeasurements =>
+      haveEqualLayout(previousMeasurements, nextMeasurements)
+        ? previousMeasurements
+        : nextMeasurements,
+    );
     return nextMeasurements.size === blockMap.size;
   }, [blockMap]);
 
@@ -222,11 +249,20 @@ export function useDraftEditorBlockWindowing({
     );
     renderedKeys.add(editorState.selection.anchorKey);
     renderedKeys.add(editorState.selection.focusKey);
+    for (const blockKey of pinnedBlockKeys || []) {
+      renderedKeys.add(blockKey);
+    }
     return {
       shouldRenderBlock: block => renderedKeys.has(block.key),
       getSpacerHeight: block => blockLayout.heights.get(block.key) || 0,
     };
-  }, [blockLayout, editorState.selection.anchorKey, editorState.selection.focusKey, windowRange]);
+  }, [
+    blockLayout,
+    editorState.selection.anchorKey,
+    editorState.selection.focusKey,
+    pinnedBlockKeys,
+    windowRange,
+  ]);
 }
 
-export const exportedForTesting = {getWindowRange};
+export const exportedForTesting = {getWindowRange, haveEqualLayout};

--- a/src/component/hooks/useDraftEditorBlockWindowing.ts
+++ b/src/component/hooks/useDraftEditorBlockWindowing.ts
@@ -1,12 +1,3 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- * @format
- */
-
 import {
   RefObject,
   useCallback,

--- a/src/component/hooks/useDraftEditorBlockWindowing.ts
+++ b/src/component/hooks/useDraftEditorBlockWindowing.ts
@@ -1,0 +1,241 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import {
+  RefObject,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {EditorState} from '../../model/immutable/EditorState';
+import {BlockNode} from '../../model/immutable/BlockNode';
+import {DraftEditorBlockWindowing} from '../base/DraftEditorProps';
+
+type BlockMeasurement = {
+  block: BlockNode;
+  height: number;
+};
+
+type BlockLayout = {
+  keys: string[];
+  offsets: number[];
+  heights: Map<string, number>;
+};
+
+export type DraftEditorBlockWindowingOptions = {
+  enabled: boolean;
+  editorState: EditorState;
+  scrollContainerRef: RefObject<HTMLElement>;
+  editorContainerRef: RefObject<HTMLElement>;
+  layoutKey?: unknown;
+};
+
+function getWindowRange(
+  blockLayout: BlockLayout,
+  viewportStart: number,
+  viewportEnd: number,
+): {start: number; end: number} {
+  let start = 0;
+  while (start < blockLayout.keys.length) {
+    const blockKey = blockLayout.keys[start];
+    const blockOffset = blockLayout.offsets[start];
+    if (
+      blockKey === undefined ||
+      blockOffset === undefined ||
+      blockOffset + (blockLayout.heights.get(blockKey) || 0) >= viewportStart
+    ) {
+      break;
+    }
+    start += 1;
+  }
+
+  let end = start;
+  while (end < blockLayout.keys.length) {
+    const blockOffset = blockLayout.offsets[end];
+    if (blockOffset === undefined || blockOffset > viewportEnd) {
+      break;
+    }
+    end += 1;
+  }
+  return {start, end};
+}
+
+function measureBlocks(
+  blocks: ReadonlyMap<string, BlockNode>,
+  previousMeasurements: ReadonlyMap<string, BlockMeasurement>,
+): Map<string, BlockMeasurement> {
+  const measurements = new Map<string, BlockMeasurement>();
+  const lastBlockKey = Array.from(blocks.keys()).pop();
+  for (const block of blocks.values()) {
+    const element = document.getElementById(`block-${block.key}`);
+    if (element) {
+      const marginBottom =
+        block.key === lastBlockKey
+          ? 0
+          : parseFloat(getComputedStyle(element).marginBottom) || 0;
+      measurements.set(block.key, {
+        block,
+        height: element.getBoundingClientRect().height + marginBottom,
+      });
+      continue;
+    }
+
+    const previousMeasurement = previousMeasurements.get(block.key);
+    if (previousMeasurement?.block === block) {
+      measurements.set(block.key, previousMeasurement);
+    }
+  }
+  return measurements;
+}
+
+export function useDraftEditorBlockWindowing({
+  enabled,
+  editorState,
+  scrollContainerRef,
+  editorContainerRef,
+  layoutKey,
+}: DraftEditorBlockWindowingOptions): DraftEditorBlockWindowing | undefined {
+  const blockMap = editorState.currentContent.blockMap;
+  const measurementsRef = useRef<ReadonlyMap<string, BlockMeasurement>>(new Map());
+  const [measurements, setMeasurements] = useState<
+    ReadonlyMap<string, BlockMeasurement>
+  >(new Map());
+  const [needsFullMeasurement, setNeedsFullMeasurement] = useState(false);
+  const [measurementRevision, setMeasurementRevision] = useState(0);
+  const [windowRange, setWindowRange] = useState<{start: number; end: number}>();
+
+  const updateMeasurements = useCallback(() => {
+    const nextMeasurements = measureBlocks(blockMap, measurementsRef.current);
+    measurementsRef.current = nextMeasurements;
+    setMeasurements(nextMeasurements);
+    return nextMeasurements.size === blockMap.size;
+  }, [blockMap]);
+
+  useLayoutEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    const animationFrame = requestAnimationFrame(() => {
+      setNeedsFullMeasurement(!updateMeasurements());
+    });
+    return () => cancelAnimationFrame(animationFrame);
+  }, [enabled, layoutKey, measurementRevision, updateMeasurements]);
+
+  useLayoutEffect(() => {
+    if (!enabled || !needsFullMeasurement) {
+      return;
+    }
+    const animationFrame = requestAnimationFrame(() => {
+      updateMeasurements();
+      setNeedsFullMeasurement(false);
+    });
+    return () => cancelAnimationFrame(animationFrame);
+  }, [enabled, needsFullMeasurement, updateMeasurements]);
+
+  useEffect(() => {
+    const editorContainer = editorContainerRef.current;
+    if (!enabled || !editorContainer || typeof ResizeObserver === 'undefined') {
+      return;
+    }
+    const resizeObserver = new ResizeObserver(() => {
+      measurementsRef.current = new Map();
+      setMeasurements(new Map());
+      setMeasurementRevision(revision => revision + 1);
+    });
+    resizeObserver.observe(editorContainer);
+    return () => resizeObserver.disconnect();
+  }, [editorContainerRef, enabled]);
+
+  const blockLayout = useMemo<BlockLayout | undefined>(() => {
+    if (!enabled || measurements.size !== blockMap.size) {
+      return undefined;
+    }
+    const keys: string[] = [];
+    const offsets: number[] = [];
+    const heights = new Map<string, number>();
+    let offset = 0;
+    for (const block of blockMap.values()) {
+      const measurement = measurements.get(block.key);
+      if (!measurement) {
+        return undefined;
+      }
+      keys.push(block.key);
+      offsets.push(offset);
+      heights.set(block.key, measurement.height);
+      offset += measurement.height;
+    }
+    return {keys, offsets, heights};
+  }, [blockMap, enabled, measurements]);
+
+  useEffect(() => {
+    const scrollContainer = scrollContainerRef.current;
+    const editorContainer = editorContainerRef.current;
+    if (!blockLayout || !scrollContainer || !editorContainer) {
+      return;
+    }
+    const contents = editorContainer.querySelector<HTMLElement>('[data-contents="true"]');
+    if (!contents) {
+      return;
+    }
+    const scrollRect = scrollContainer.getBoundingClientRect();
+    const contentsRect = contents.getBoundingClientRect();
+    const contentOffset = contentsRect.top - scrollRect.top + scrollContainer.scrollTop;
+    const viewportHeight = scrollContainer.clientHeight;
+    const overscan = Math.max(viewportHeight * 1.5, 1200);
+
+    let animationFrame: number | undefined;
+    const updateWindow = () => {
+      animationFrame = undefined;
+      const viewportStart = scrollContainer.scrollTop - contentOffset - overscan;
+      const viewportEnd = viewportStart + viewportHeight + overscan * 2;
+      const nextRange = getWindowRange(blockLayout, viewportStart, viewportEnd);
+      setWindowRange(previousRange =>
+        previousRange?.start === nextRange.start && previousRange.end === nextRange.end
+          ? previousRange
+          : nextRange,
+      );
+    };
+    const scheduleUpdate = () => {
+      if (animationFrame === undefined) {
+        animationFrame = requestAnimationFrame(updateWindow);
+      }
+    };
+
+    updateWindow();
+    scrollContainer.addEventListener('scroll', scheduleUpdate, {passive: true});
+    window.addEventListener('resize', scheduleUpdate);
+    return () => {
+      scrollContainer.removeEventListener('scroll', scheduleUpdate);
+      window.removeEventListener('resize', scheduleUpdate);
+      if (animationFrame !== undefined) {
+        cancelAnimationFrame(animationFrame);
+      }
+    };
+  }, [blockLayout, editorContainerRef, scrollContainerRef]);
+
+  return useMemo<DraftEditorBlockWindowing | undefined>(() => {
+    if (!blockLayout || !windowRange) {
+      return undefined;
+    }
+    const renderedKeys = new Set(
+      blockLayout.keys.slice(windowRange.start, windowRange.end),
+    );
+    renderedKeys.add(editorState.selection.anchorKey);
+    renderedKeys.add(editorState.selection.focusKey);
+    return {
+      shouldRenderBlock: block => renderedKeys.has(block.key),
+      getSpacerHeight: block => blockLayout.heights.get(block.key) || 0,
+    };
+  }, [blockLayout, editorState.selection.anchorKey, editorState.selection.focusKey, windowRange]);
+}
+
+export const exportedForTesting = {getWindowRange};

--- a/src/component/hooks/useDraftEditorBlockWindowing.ts
+++ b/src/component/hooks/useDraftEditorBlockWindowing.ts
@@ -9,7 +9,7 @@ import {
 } from 'react';
 import {EditorState} from '../../model/immutable/EditorState';
 import {BlockNode} from '../../model/immutable/BlockNode';
-import {DraftEditorBlockWindowing} from '../base/DraftEditorProps';
+import {DraftEditorBlockWindowingOptions} from '../base/DraftEditorProps';
 
 type BlockMeasurement = {
   height: number;
@@ -21,13 +21,15 @@ type BlockLayout = {
   heights: Map<string, number>;
 };
 
-export type DraftEditorBlockWindowingOptions = {
-  enabled: boolean;
+export type DraftEditorBlockWindowingState = {
+  shouldRenderBlock: (block: BlockNode) => boolean;
+  getSpacerHeight: (block: BlockNode) => number;
+};
+
+type UseDraftEditorBlockWindowingOptions = DraftEditorBlockWindowingOptions & {
   editorState: EditorState;
-  scrollContainerRef: RefObject<HTMLElement>;
   editorContainerRef: RefObject<HTMLElement>;
   layoutKey?: unknown;
-  pinnedBlockKeys?: ReadonlySet<string>;
 };
 
 function haveEqualLayout(
@@ -170,7 +172,9 @@ export function useDraftEditorBlockWindowing({
   editorContainerRef,
   layoutKey,
   pinnedBlockKeys,
-}: DraftEditorBlockWindowingOptions): DraftEditorBlockWindowing | undefined {
+}: UseDraftEditorBlockWindowingOptions):
+  | DraftEditorBlockWindowingState
+  | undefined {
   const blockMap = editorState.currentContent.blockMap;
   const measurementsRef = useRef<ReadonlyMap<string, BlockMeasurement>>(new Map());
   const measuredWidthRef = useRef<number>();
@@ -290,7 +294,7 @@ export function useDraftEditorBlockWindowing({
     };
   }, [blockLayout, editorContainerRef, scrollContainerRef]);
 
-  return useMemo<DraftEditorBlockWindowing | undefined>(() => {
+  return useMemo<DraftEditorBlockWindowingState | undefined>(() => {
     if (!blockLayout || !windowRange) {
       return undefined;
     }

--- a/src/component/hooks/useDraftEditorBlockWindowing.ts
+++ b/src/component/hooks/useDraftEditorBlockWindowing.ts
@@ -12,7 +12,6 @@ import {BlockNode} from '../../model/immutable/BlockNode';
 import {DraftEditorBlockWindowing} from '../base/DraftEditorProps';
 
 type BlockMeasurement = {
-  block: BlockNode;
   height: number;
 };
 
@@ -96,18 +95,72 @@ function measureBlocks(
           ? 0
           : parseFloat(getComputedStyle(element).marginBottom) || 0;
       measurements.set(block.key, {
-        block,
         height: element.getBoundingClientRect().height + marginBottom,
       });
       continue;
     }
 
     const previousMeasurement = previousMeasurements.get(block.key);
-    if (previousMeasurement?.block === block) {
+    if (previousMeasurement) {
       measurements.set(block.key, previousMeasurement);
     }
   }
   return measurements;
+}
+
+function getBlockLayout(
+  blocks: ReadonlyMap<string, BlockNode>,
+  measurements: ReadonlyMap<string, BlockMeasurement>,
+): BlockLayout | undefined {
+  const blockEntries = Array.from(blocks.entries());
+  const retainedHeights = blockEntries
+    .map(([key]) => measurements.get(key)?.height)
+    .filter((height): height is number => height !== undefined);
+  if (blockEntries.length > 0 && retainedHeights.length === 0) {
+    return undefined;
+  }
+
+  const sortedHeights = Array.from(measurements.values(), ({height}) => height).sort(
+    (a, b) => a - b,
+  );
+  const fallbackHeight = sortedHeights[Math.floor(sortedHeights.length / 2)] || 0;
+  const nextMeasuredHeights: Array<number | undefined> = new Array(
+    blockEntries.length,
+  );
+  let nextMeasuredHeight: number | undefined;
+  for (let index = blockEntries.length - 1; index >= 0; index -= 1) {
+    const blockEntry = blockEntries[index];
+    const measuredHeight = blockEntry
+      ? measurements.get(blockEntry[0])?.height
+      : undefined;
+    if (measuredHeight !== undefined) {
+      nextMeasuredHeight = measuredHeight;
+    }
+    nextMeasuredHeights[index] = nextMeasuredHeight;
+  }
+
+  const keys: string[] = [];
+  const offsets: number[] = [];
+  const heights = new Map<string, number>();
+  let offset = 0;
+  let previousMeasuredHeight: number | undefined;
+  for (const [index, [key]] of blockEntries.entries()) {
+    const measuredHeight = measurements.get(key)?.height;
+    const nextHeight = nextMeasuredHeights[index];
+    const height =
+      measuredHeight ??
+      (previousMeasuredHeight !== undefined && nextHeight !== undefined
+        ? (previousMeasuredHeight + nextHeight) / 2
+        : previousMeasuredHeight ?? nextHeight ?? fallbackHeight);
+    keys.push(key);
+    offsets.push(offset);
+    heights.set(key, height);
+    offset += height;
+    if (measuredHeight !== undefined) {
+      previousMeasuredHeight = measuredHeight;
+    }
+  }
+  return {keys, offsets, heights};
 }
 
 export function useDraftEditorBlockWindowing({
@@ -120,10 +173,10 @@ export function useDraftEditorBlockWindowing({
 }: DraftEditorBlockWindowingOptions): DraftEditorBlockWindowing | undefined {
   const blockMap = editorState.currentContent.blockMap;
   const measurementsRef = useRef<ReadonlyMap<string, BlockMeasurement>>(new Map());
+  const measuredWidthRef = useRef<number>();
   const [measurements, setMeasurements] = useState<
     ReadonlyMap<string, BlockMeasurement>
   >(new Map());
-  const [needsFullMeasurement, setNeedsFullMeasurement] = useState(false);
   const [measurementRevision, setMeasurementRevision] = useState(0);
   const [windowRange, setWindowRange] = useState<{start: number; end: number}>();
 
@@ -143,55 +196,52 @@ export function useDraftEditorBlockWindowing({
       return;
     }
     const animationFrame = requestAnimationFrame(() => {
-      setNeedsFullMeasurement(!updateMeasurements());
+      updateMeasurements();
     });
     return () => cancelAnimationFrame(animationFrame);
   }, [enabled, layoutKey, measurementRevision, updateMeasurements]);
 
   useLayoutEffect(() => {
-    if (!enabled || !needsFullMeasurement) {
+    if (!enabled || measurements.size >= blockMap.size || !windowRange) {
       return;
     }
     const animationFrame = requestAnimationFrame(() => {
       updateMeasurements();
-      setNeedsFullMeasurement(false);
     });
     return () => cancelAnimationFrame(animationFrame);
-  }, [enabled, needsFullMeasurement, updateMeasurements]);
+  }, [blockMap.size, enabled, measurements.size, updateMeasurements, windowRange]);
 
   useEffect(() => {
     const editorContainer = editorContainerRef.current;
     if (!enabled || !editorContainer || typeof ResizeObserver === 'undefined') {
       return;
     }
-    const resizeObserver = new ResizeObserver(() => {
+    const resizeObserver = new ResizeObserver(entries => {
+      const width = entries[0]?.contentRect.width;
+      if (width === undefined) {
+        return;
+      }
+      const previousWidth = measuredWidthRef.current;
+      measuredWidthRef.current = width;
+      if (previousWidth === undefined || width === previousWidth) {
+        return;
+      }
       measurementsRef.current = new Map();
       setMeasurements(new Map());
       setMeasurementRevision(revision => revision + 1);
     });
     resizeObserver.observe(editorContainer);
-    return () => resizeObserver.disconnect();
+    return () => {
+      measuredWidthRef.current = undefined;
+      resizeObserver.disconnect();
+    };
   }, [editorContainerRef, enabled]);
 
   const blockLayout = useMemo<BlockLayout | undefined>(() => {
-    if (!enabled || measurements.size !== blockMap.size) {
+    if (!enabled) {
       return undefined;
     }
-    const keys: string[] = [];
-    const offsets: number[] = [];
-    const heights = new Map<string, number>();
-    let offset = 0;
-    for (const block of blockMap.values()) {
-      const measurement = measurements.get(block.key);
-      if (!measurement) {
-        return undefined;
-      }
-      keys.push(block.key);
-      offsets.push(offset);
-      heights.set(block.key, measurement.height);
-      offset += measurement.height;
-    }
-    return {keys, offsets, heights};
+    return getBlockLayout(blockMap, measurements);
   }, [blockMap, enabled, measurements]);
 
   useEffect(() => {
@@ -265,4 +315,8 @@ export function useDraftEditorBlockWindowing({
   ]);
 }
 
-export const exportedForTesting = {getWindowRange, haveEqualLayout};
+export const exportedForTesting = {
+  getBlockLayout,
+  getWindowRange,
+  haveEqualLayout,
+};


### PR DESCRIPTION
## Summary

Adds opt-in block windowing while keeping the generic lifecycle and DOM protocol inside the Draft fork:

- `useDraftEditorBlockWindowing` owns measurement, resize invalidation, viewport/overscan calculation, selection-endpoint pinning, and consumer-supplied pinned block keys.
- Stable measurements preserve object identity when ordered block heights have not changed, avoiding a redundant contents render after each edit.
- Structural edits retain measured heights by block key and estimate only new keys from their measured neighbors until the new blocks render.
- Height-only editor resizes no longer invalidate the entire layout; width changes still trigger a full remeasurement because text wrapping can change every block's height.
- `DraftEditor` replaces omitted runs with inert height spacers while preserving custom block elements and wrapper runs across window seams.
- Offset helpers map both directions needed by consumers: viewport positions to Draft text offsets and Draft text offsets to block keys.

Also bumps the package to `0.11.6-descript.35` for the dependent Descript PR.

Dependent PR: https://github.com/descriptinc/descript/pull/36590

## Test plan

- `mise exec node@20 -- pnpm exec jest --runInBand --no-watchman src/component/hooks/__tests__/useDraftEditorBlockWindowing-test.ts src/component/contents/__tests__/getDraftEditorWindowedTextOffset-test.ts src/component/contents/__tests__/DraftEditorContents.react-test.tsx` (14 tests pass)
- ESLint passes for all changed source and test files.
- `mise exec node@20 -- pnpm build` completes and emits the new declarations.

The focused tests cover window-range math, stable measurement equality, hook lifecycle and pinning, structural edits with height-only resize notifications, spacer offset mapping, and custom wrapper continuity. Repository-wide declaration checking still reports the fork's existing Node-global and old TypeScript lib-target warnings in unrelated files.
