### PR TITLE
Add offscreen block skeletons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@descript/draft-js",
     "description": "A React framework for building text editors.",
-    "version": "0.11.6-descript.36",
+    "version": "0.11.6-descript.37",
     "keywords": [
         "draftjs",
         "editor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@descript/draft-js",
     "description": "A React framework for building text editors.",
-    "version": "0.11.6-descript.38",
+    "version": "0.11.6-descript.39",
     "keywords": [
         "draftjs",
         "editor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@descript/draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.11.6-descript.34",
+  "version": "0.11.6-descript.36",
   "keywords": [
     "draftjs",
     "editor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@descript/draft-js",
     "description": "A React framework for building text editors.",
-    "version": "0.11.6-descript.37",
+    "version": "0.11.6-descript.38",
     "keywords": [
         "draftjs",
         "editor",

--- a/package.json
+++ b/package.json
@@ -1,152 +1,147 @@
 {
-  "name": "@descript/draft-js",
-  "description": "A React framework for building text editors.",
-  "version": "0.11.6-descript.36",
-  "keywords": [
-    "draftjs",
-    "editor",
-    "react",
-    "richtext"
-  ],
-  "homepage": "http://draftjs.org/",
-  "bugs": "https://github.com/facebook/draft-js/issues",
-  "files": [
-    "dist/",
-    "lib/",
-    "LICENSE"
-  ],
-  "main": "./lib/cjs/Draft.js",
-  "module": "./lib/esm/Draft.js",
-  "types": "./lib/types/Draft.d.ts",
-  "style": "./dist/Draft.css",
-  "exports": {
-    ".": {
-      "types": "./lib/types/Draft.d.ts",
-      "import": "./lib/esm/Draft.js",
-      "require": "./lib/cjs/Draft.js"
+    "name": "@descript/draft-js",
+    "description": "A React framework for building text editors.",
+    "version": "0.11.6-descript.36",
+    "keywords": [
+        "draftjs",
+        "editor",
+        "react",
+        "richtext"
+    ],
+    "homepage": "http://draftjs.org/",
+    "bugs": "https://github.com/facebook/draft-js/issues",
+    "files": [
+        "dist/",
+        "lib/",
+        "LICENSE"
+    ],
+    "main": "./lib/cjs/Draft.js",
+    "module": "./lib/esm/Draft.js",
+    "types": "./lib/types/Draft.d.ts",
+    "style": "./dist/Draft.css",
+    "exports": {
+        ".": {
+            "types": "./lib/types/Draft.d.ts",
+            "import": "./lib/esm/Draft.js",
+            "require": "./lib/cjs/Draft.js"
+        },
+        "./dist/Draft.css": "./dist/Draft.css"
     },
-    "./dist/Draft.css": "./dist/Draft.css"
-  },
-  "repository": "facebook/draft-js",
-  "license": "MIT",
-  "scripts": {
-    "prepublish": "npm run build",
-    "pretest": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json",
-    "build": "npm run clean && npm run build:lib && npm run build:umd && npm run build:css",
-    "build:lib": "vite build",
-    "build:umd": "vite build --config vite.config.umd.ts",
-    "build:css": "vite build --config vite.config.css.ts && rm -f dist/dummy.js",
-    "build:watch": "vite build --watch",
-    "clean": "rm -rf lib dist",
-    "dev": "vite build --watch",
-    "typecheck": "tsc --noEmit",
-    "examples": "pnpm --filter @descript/draft-js-examples dev",
-    "examples:build": "pnpm --filter @descript/draft-js-examples build",
-    "examples:preview": "pnpm --filter @descript/draft-js-examples preview",
-    "lint": "eslint src/.",
-    "lint-docs": "alex . && pnpm format-docs:diff",
-    "format": "eslint . --fix",
-    "format-docs": "prettier --config prettier.config.js --write \"docs/**/*.md\"",
-    "format-docs:diff": "prettier --config prettier.config.js --list-different \"docs/**/*.md\"",
-    "test": "cross-env NODE_ENV=test jest",
-    "test-ci": "cross-env NODE_ENV=test npm run lint && npm run test"
-  },
-  "dependencies": {
-    "fast-deep-equal": "^3.1.3",
-    "fbjs": "^1.0.0",
-    "memoize-one": "^5.1.1",
-    "object-assign": "^4.1.1"
-  },
-  "peerDependencies": {
-    "react": ">=16.0.0",
-    "react-dom": ">=16.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@types/react": {
-      "optional": true
+    "repository": "facebook/draft-js",
+    "license": "MIT",
+    "scripts": {
+        "prepublish": "pnpm run build",
+        "build": "pnpm run clean && pnpm run build:lib && pnpm run build:umd && pnpm run build:css",
+        "build:lib": "vite build",
+        "build:umd": "vite build --config vite.config.umd.ts",
+        "build:css": "vite build --config vite.config.css.ts && rm -f dist/dummy.js",
+        "build:watch": "vite build --watch",
+        "clean": "rm -rf lib dist",
+        "dev": "vite build --watch",
+        "typecheck": "tsc --noEmit",
+        "examples": "pnpm --filter @descript/draft-js-examples dev",
+        "examples:build": "pnpm --filter @descript/draft-js-examples build",
+        "examples:preview": "pnpm --filter @descript/draft-js-examples preview",
+        "lint": "eslint src/.",
+        "lint-docs": "alex . && pnpm format-docs:diff",
+        "format": "eslint . --fix",
+        "format-docs": "prettier --config prettier.config.js --write \"docs/**/*.md\"",
+        "format-docs:diff": "prettier --config prettier.config.js --list-different \"docs/**/*.md\"",
+        "test": "cross-env NODE_ENV=test jest",
+        "test-ci": "cross-env NODE_ENV=test pnpm run lint && pnpm run test"
     },
-    "@types/react-dom": {
-      "optional": true
-    }
-  },
-  "devDependencies": {
-    "@babel/core": "^7.6.4",
-    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",
-    "@babel/plugin-proposal-optional-chaining": "^7.9.0",
-    "@types/jest": "^29.5.4",
-    "@types/react": "^18.3.24",
-    "@types/react-dom": "^18.3.7",
-    "@typescript-eslint/eslint-plugin": "^8.44.1",
-    "@typescript-eslint/parser": "^8.44.1",
-    "@vitejs/plugin-react": "^4.3.3",
-    "alex": "^8.0.0",
-    "babel-eslint": "^10.1.0",
-    "babel-preset-fbjs": "^3.3.0",
-    "cross-env": "^7.0.2",
-    "es6-shim": "^0.35.5",
-    "eslint": "^8.49.0",
-    "eslint-config-fbjs": "^4.0.0",
-    "eslint-config-prettier": "^9.0.0",
-    "eslint-plugin-babel": "^5.3.1",
-    "eslint-plugin-jsx-a11y": "^6.7.1",
-    "eslint-plugin-react": "^7.33.2",
-    "fbjs-scripts": "^1.2.0",
-    "jest": "^29.6.4",
-    "jest-environment-jsdom": "^29.6.4",
-    "postcss": "^8.4.49",
-    "prettier": "1.19.1",
-    "react": "^19.1.1",
-    "react-dom": "^19.1.1",
-    "react-test-renderer": "^18.3.1",
-    "rollup-plugin-visualizer": "^5.12.0",
-    "ts-jest": "^29.1.1",
-    "typescript": "^5.9.2",
-    "vite": "^5.4.11",
-    "vite-plugin-dts": "^4.3.0"
-  },
-  "devEngines": {
-    "node": "14.x || 16.x || 18.x || 20.x",
-    "npm": "2.x || 3.x || 5.x || 6.x || 7.x || 8.x || 9.x || 10.x"
-  },
-  "jest": {
-    "preset": "ts-jest",
-    "testEnvironment": "jsdom",
-    "globals": {
-      "__DEV__": true,
-      "ts-jest": {
-        "diagnostics": {
-          "warnOnly": true
+    "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fbjs": "^1.0.0",
+        "memoize-one": "^5.1.1",
+        "object-assign": "^4.1.1"
+    },
+    "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+    },
+    "peerDependenciesMeta": {
+        "@types/react": {
+            "optional": true
+        },
+        "@types/react-dom": {
+            "optional": true
         }
-      }
     },
-    "rootDir": "./",
-    "roots": [
-      "<rootDir>/src/"
-    ],
-    "setupFiles": [
-      "<rootDir>/scripts/jest/shims.js"
-    ],
-    "setupFilesAfterEnv": [
-      "<rootDir>/scripts/jest/setupAfterEnv.ts"
-    ],
-    "haste": {
-      "hasteImplModulePath": "<rootDir>/scripts/jest/hasteImpl.js"
+    "devDependencies": {
+        "@babel/core": "^7.6.4",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",
+        "@babel/plugin-proposal-optional-chaining": "^7.9.0",
+        "@types/jest": "^29.5.4",
+        "@types/react": "^18.3.24",
+        "@types/react-dom": "^18.3.7",
+        "@typescript-eslint/eslint-plugin": "^8.44.1",
+        "@typescript-eslint/parser": "^8.44.1",
+        "@vitejs/plugin-react": "^4.3.3",
+        "alex": "^8.0.0",
+        "babel-eslint": "^10.1.0",
+        "babel-preset-fbjs": "^3.3.0",
+        "cross-env": "^7.0.2",
+        "es6-shim": "^0.35.5",
+        "eslint": "^8.49.0",
+        "eslint-config-fbjs": "^4.0.0",
+        "eslint-config-prettier": "^9.0.0",
+        "eslint-plugin-babel": "^5.3.1",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
+        "eslint-plugin-react": "^7.33.2",
+        "fbjs-scripts": "^1.2.0",
+        "jest": "^29.6.4",
+        "jest-environment-jsdom": "^29.6.4",
+        "postcss": "^8.4.49",
+        "prettier": "1.19.1",
+        "react": "^19.1.1",
+        "react-dom": "^19.1.1",
+        "react-test-renderer": "^18.3.1",
+        "rollup-plugin-visualizer": "^5.12.0",
+        "ts-jest": "^29.1.1",
+        "typescript": "^5.9.2",
+        "vite": "^5.4.11",
+        "vite-plugin-dts": "^4.3.0"
     },
-    "modulePathIgnorePatterns": [
-      "<rootDir>/lib/",
-      "<rootDir>/node_modules/"
-    ],
-    "transformIgnorePatterns": [
-      "<rootDir>/node_modules/"
-    ],
-    "unmockedModulePathPatterns": [
-      "<rootDir>/node_modules/fbjs/node_modules/",
-      "<rootDir>/node_modules/fbjs/lib/UserAgent.js",
-      "<rootDir>/node_modules/fbjs/lib/UserAgentData.js",
-      "<rootDir>/node_modules/fbjs-scripts/",
-      "<rootDir>/node_modules/object-assign/",
-      "<rootDir>/node_modules/react/",
-      "<rootDir>/node_modules/react-dom/"
-    ]
-  }
+    "jest": {
+        "preset": "ts-jest",
+        "testEnvironment": "jsdom",
+        "globals": {
+            "__DEV__": true,
+            "ts-jest": {
+                "diagnostics": {
+                    "warnOnly": true
+                }
+            }
+        },
+        "rootDir": "./",
+        "roots": [
+            "<rootDir>/src/"
+        ],
+        "setupFiles": [
+            "<rootDir>/scripts/jest/shims.js"
+        ],
+        "setupFilesAfterEnv": [
+            "<rootDir>/scripts/jest/setupAfterEnv.ts"
+        ],
+        "haste": {
+            "hasteImplModulePath": "<rootDir>/scripts/jest/hasteImpl.js"
+        },
+        "modulePathIgnorePatterns": [
+            "<rootDir>/lib/",
+            "<rootDir>/node_modules/"
+        ],
+        "transformIgnorePatterns": [
+            "<rootDir>/node_modules/"
+        ],
+        "unmockedModulePathPatterns": [
+            "<rootDir>/node_modules/fbjs/node_modules/",
+            "<rootDir>/node_modules/fbjs/lib/UserAgent.js",
+            "<rootDir>/node_modules/fbjs/lib/UserAgentData.js",
+            "<rootDir>/node_modules/fbjs-scripts/",
+            "<rootDir>/node_modules/object-assign/",
+            "<rootDir>/node_modules/react/",
+            "<rootDir>/node_modules/react-dom/"
+        ]
+    }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - '.'
   - 'examples'
+allowBuilds:
+  core-js: set this to true or false
+  esbuild: set this to true or false

--- a/src/Draft.ts
+++ b/src/Draft.ts
@@ -14,6 +14,7 @@ export type {
   DraftEditorBlockSkeletonOptions,
   DraftEditorProps,
 } from './component/base/DraftEditorProps';
+export {supportsBlockSkeletonRendering} from './component/hooks/useDraftEditorBlockSkeleton';
 export {CompositeDecorator} from './model/decorators/CompositeDraftDecorator';
 import DraftEntity from './model/entity/DraftEntity';
 import AtomicBlockUtils from './model/modifier/AtomicBlockUtils';

--- a/src/Draft.ts
+++ b/src/Draft.ts
@@ -42,8 +42,7 @@ export type {RawDraftContentState} from './model/encoding/convertFromDraftStateT
 export type {DraftEditorCommand} from './model/constants/DraftEditorCommand';
 export type {DraftHandleValue} from './model/constants/DraftHandleValue';
 export type {
-  DraftDecoratorSkeletonAttributes,
-  DraftDecoratorSkeletonRange,
+  DraftDecoratorDOMAnchorRange,
   DraftDecoratorType,
 } from './model/decorators/DraftDecoratorType';
 export type {DraftDecorator, DraftDecoratorComponentProps} from './model/decorators/DraftDecorator';

--- a/src/Draft.ts
+++ b/src/Draft.ts
@@ -10,7 +10,10 @@
 import Editor from './component/base/DraftEditor.react';
 export {Editor};
 import DraftEditorBlock from './component/contents/DraftEditorBlock.react';
-export type {DraftEditorProps} from './component/base/DraftEditorProps';
+export type {
+  DraftEditorBlockSkeletonOptions,
+  DraftEditorProps,
+} from './component/base/DraftEditorProps';
 export {CompositeDecorator} from './model/decorators/CompositeDraftDecorator';
 import DraftEntity from './model/entity/DraftEntity';
 import AtomicBlockUtils from './model/modifier/AtomicBlockUtils';
@@ -38,7 +41,11 @@ export type {RawDraftContentState} from './model/encoding/convertFromDraftStateT
 
 export type {DraftEditorCommand} from './model/constants/DraftEditorCommand';
 export type {DraftHandleValue} from './model/constants/DraftHandleValue';
-export type {DraftDecoratorType} from './model/decorators/DraftDecoratorType';
+export type {
+  DraftDecoratorSkeletonAttributes,
+  DraftDecoratorSkeletonRange,
+  DraftDecoratorType,
+} from './model/decorators/DraftDecoratorType';
 export type {DraftDecorator, DraftDecoratorComponentProps} from './model/decorators/DraftDecorator';
 
 export const EditorBlock = DraftEditorBlock;

--- a/src/component/base/DraftEditor.react.tsx
+++ b/src/component/base/DraftEditor.react.tsx
@@ -35,7 +35,7 @@ import {hasText} from '../../model/immutable/ContentState';
 import {nullthrows} from '../../fbjs/nullthrows';
 import DraftEditorPlaceholder from './DraftEditorPlaceholder.react';
 import {DefaultDraftInlineStyle} from '../../model/immutable/DefaultDraftInlineStyle';
-import DraftEditorContents from '../contents/DraftEditorContents-core.react';
+import DraftEditorSkeletonContents from '../contents/DraftEditorSkeletonContents.react';
 
 const isIE = UserAgent.isBrowser('IE');
 
@@ -336,6 +336,7 @@ export default class DraftEditor extends React.Component<
       blockRenderMap,
       blockRendererFn,
       blockStyleFn,
+      blockSkeleton,
       customStyleFn,
       customStyleMap,
       editorState,
@@ -377,6 +378,7 @@ export default class DraftEditor extends React.Component<
       blockRenderMap,
       blockRendererFn,
       blockStyleFn,
+      blockSkeleton,
       customStyleMap: {
         ...DefaultDraftInlineStyle,
         ...customStyleMap,
@@ -471,7 +473,7 @@ export default class DraftEditor extends React.Component<
               all DraftEditorLeaf nodes so it's first in postorder traversal.
             */}
             <UpdateDraftEditorFlags editor={this} editorState={editorState} />
-            <DraftEditorContents
+            <DraftEditorSkeletonContents
               {...editorContentsProps}
               key={'contents' + this.state.contentsKey}
             />

--- a/src/component/base/DraftEditorProps.ts
+++ b/src/component/base/DraftEditorProps.ts
@@ -29,6 +29,7 @@ import {BlockNode} from '../../model/immutable/BlockNode';
 export type DraftEditorBlockSkeletonOptions = Readonly<{
   enabled: boolean;
   scrollContainerRef: RefObject<HTMLElement>;
+  onBlockSkeletonsRendered?: () => void;
 }>;
 
 export type DraftEditorProps = {

--- a/src/component/base/DraftEditorProps.ts
+++ b/src/component/base/DraftEditorProps.ts
@@ -29,7 +29,6 @@ import {BlockNode} from '../../model/immutable/BlockNode';
 export type DraftEditorBlockSkeletonOptions = Readonly<{
   enabled: boolean;
   scrollContainerRef: RefObject<HTMLElement>;
-  pinnedBlockKeys?: ReadonlySet<string>;
 }>;
 
 export type DraftEditorProps = {

--- a/src/component/base/DraftEditorProps.ts
+++ b/src/component/base/DraftEditorProps.ts
@@ -26,6 +26,12 @@ import {
 } from '../utils/eventTypes';
 import {BlockNode} from '../../model/immutable/BlockNode';
 
+export type DraftEditorBlockSkeletonOptions = Readonly<{
+  enabled: boolean;
+  scrollContainerRef: RefObject<HTMLElement>;
+  pinnedBlockKeys?: ReadonlySet<string>;
+}>;
+
 export type DraftEditorProps = {
   /**
    * The two most critical props are `editorState` and `onChange`.
@@ -60,6 +66,8 @@ export type DraftEditorProps = {
   blockRendererFn: (block: BlockNode) => any | null;
   // Function that returns a cx map corresponding to block-level styles.
   blockStyleFn: (block: BlockNode) => string | CSSProperties | undefined;
+  // Replace offscreen block contents with text-only skeletons.
+  blockSkeleton?: DraftEditorBlockSkeletonOptions;
   // If supplied, a ref which will be passed to the contenteditable.
   // Currently, only object refs are supported.
   editorRef?: RefObject<HTMLDivElement> | Ref<HTMLDivElement>;

--- a/src/component/base/__tests__/DraftEditor.react-test.tsx
+++ b/src/component/base/__tests__/DraftEditor.react-test.tsx
@@ -298,6 +298,95 @@ test('renders newly introduced block keys as skeletons immediately', () => {
   }
 });
 
+test('keeps a promoted block full when its DOM node is moved', () => {
+  const originalIntersectionObserver = globalThis.IntersectionObserver;
+  const originalMutationObserver = globalThis.MutationObserver;
+  let intersectionCallback: IntersectionObserverCallback | undefined;
+  let mutationCallback: MutationCallback | undefined;
+
+  class MockIntersectionObserver implements IntersectionObserver {
+    readonly root = container;
+    readonly rootMargin = '500px 0px';
+    readonly thresholds = [0];
+
+    constructor(callback: IntersectionObserverCallback) {
+      intersectionCallback = callback;
+    }
+
+    disconnect(): void {}
+    observe(): void {}
+    takeRecords(): IntersectionObserverEntry[] {
+      return [];
+    }
+    unobserve(): void {}
+  }
+
+  class MockMutationObserver implements MutationObserver {
+    constructor(callback: MutationCallback) {
+      mutationCallback = callback;
+    }
+
+    disconnect(): void {}
+    observe(): void {}
+    takeRecords(): MutationRecord[] {
+      return [];
+    }
+  }
+
+  globalThis.IntersectionObserver = MockIntersectionObserver;
+  globalThis.MutationObserver = MockMutationObserver;
+  try {
+    editorState = createWithContent(createFromText('zero\none\ntwo'));
+    flushSync(() => {
+      root.render(
+        <DraftEditor
+          editorState={editorState}
+          onChange={() => {}}
+          blockSkeleton={{
+            enabled: true,
+            scrollContainerRef: {current: container},
+          }}
+        />,
+      );
+    });
+
+    const secondBlock = container.querySelectorAll('[data-block-key]')[1]!;
+    flushSync(() => {
+      intersectionCallback?.(
+        [
+          {
+            isIntersecting: true,
+            target: secondBlock,
+          } as IntersectionObserverEntry,
+        ],
+        {} as IntersectionObserver,
+      );
+    });
+    expect(secondBlock.hasAttribute('data-block-skeleton')).toBe(false);
+
+    flushSync(() => {
+      mutationCallback?.(
+        [
+          ({
+            addedNodes: [secondBlock],
+            removedNodes: [secondBlock],
+          } as unknown) as MutationRecord,
+        ],
+        {} as MutationObserver,
+      );
+    });
+
+    expect(
+      container.querySelectorAll('[data-block-key]')[1]!.hasAttribute(
+        'data-block-skeleton',
+      ),
+    ).toBe(false);
+  } finally {
+    globalThis.IntersectionObserver = originalIntersectionObserver;
+    globalThis.MutationObserver = originalMutationObserver;
+  }
+});
+
 test('renders full blocks when native scroll anchoring is unsupported', () => {
   const originalCSS = globalThis.CSS;
   const originalIntersectionObserver = globalThis.IntersectionObserver;

--- a/src/component/base/__tests__/DraftEditor.react-test.tsx
+++ b/src/component/base/__tests__/DraftEditor.react-test.tsx
@@ -156,6 +156,59 @@ test('promotes intersecting skeleton blocks to full rendering', () => {
   }
 });
 
+test('promotes viewport skeleton blocks synchronously while scrolling', () => {
+  const originalIntersectionObserver = globalThis.IntersectionObserver;
+
+  class MockIntersectionObserver implements IntersectionObserver {
+    readonly root = container;
+    readonly rootMargin = '500px 0px';
+    readonly thresholds = [0];
+
+    disconnect(): void {}
+    observe(): void {}
+    takeRecords(): IntersectionObserverEntry[] {
+      return [];
+    }
+    unobserve(): void {}
+  }
+
+  globalThis.IntersectionObserver = MockIntersectionObserver;
+  try {
+    editorState = createWithContent(createFromText('zero\none\ntwo'));
+    flushSync(() => {
+      root.render(
+        <DraftEditor
+          editorState={editorState}
+          onChange={() => {}}
+          blockSkeleton={{
+            enabled: true,
+            scrollContainerRef: {current: container},
+          }}
+        />,
+      );
+    });
+
+    container.getBoundingClientRect = () =>
+      ({top: 0, bottom: 100} as DOMRect);
+    const blocks = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-block-key]'),
+    );
+    blocks[0]!.getBoundingClientRect = () =>
+      ({top: -40, bottom: -20} as DOMRect);
+    blocks[1]!.getBoundingClientRect = () =>
+      ({top: 20, bottom: 40} as DOMRect);
+    blocks[2]!.getBoundingClientRect = () =>
+      ({top: 120, bottom: 140} as DOMRect);
+
+    container.dispatchEvent(new Event('scroll'));
+
+    expect(blocks[1]!.hasAttribute('data-block-skeleton')).toBe(false);
+    expect(blocks[2]!.hasAttribute('data-block-skeleton')).toBe(true);
+  } finally {
+    globalThis.IntersectionObserver = originalIntersectionObserver;
+  }
+});
+
 test('renders newly introduced block keys as skeletons immediately', () => {
   const originalIntersectionObserver = globalThis.IntersectionObserver;
   const originalMutationObserver = globalThis.MutationObserver;

--- a/src/component/base/__tests__/DraftEditor.react-test.tsx
+++ b/src/component/base/__tests__/DraftEditor.react-test.tsx
@@ -82,6 +82,7 @@ test('promotes intersecting skeleton blocks to full rendering', () => {
   let observerCallback: IntersectionObserverCallback | undefined;
   let observerCount = 0;
   const observedElements: Element[] = [];
+  const renderedSkeletonCounts: number[] = [];
 
   class MockIntersectionObserver implements IntersectionObserver {
     readonly root = container;
@@ -111,12 +112,13 @@ test('promotes intersecting skeleton blocks to full rendering', () => {
         <DraftEditor
           editorState={editorState}
           onChange={() => {}}
-          blockStyleFn={() => ({
-            containIntrinsicSize: '1px 20px',
-            contentVisibility: 'auto',
-          })}
           blockSkeleton={{
             enabled: true,
+            onBlockSkeletonsRendered: () => {
+              renderedSkeletonCounts.push(
+                container.querySelectorAll('[data-block-skeleton]').length,
+              );
+            },
             scrollContainerRef: {current: container},
           }}
         />,
@@ -126,13 +128,10 @@ test('promotes intersecting skeleton blocks to full rendering', () => {
     expect(observedElements).toHaveLength(3);
     expect(observerCount).toBe(1);
     expect(container.querySelectorAll('[data-block-skeleton]')).toHaveLength(2);
+    expect(renderedSkeletonCounts).toEqual([2]);
 
     const secondBlock = observedElements[1];
     expect(secondBlock).toBeDefined();
-    expect((secondBlock as HTMLElement).style.contentVisibility).toBe('auto');
-    expect((secondBlock as HTMLElement).style.containIntrinsicSize).toBe(
-      '1px 20px',
-    );
     flushSync(() => {
       observerCallback?.(
         [
@@ -146,10 +145,7 @@ test('promotes intersecting skeleton blocks to full rendering', () => {
     });
 
     expect(container.querySelectorAll('[data-block-skeleton]')).toHaveLength(1);
-    expect((secondBlock as HTMLElement).style.contentVisibility).toBe(
-      'visible',
-    );
-    expect((secondBlock as HTMLElement).style.containIntrinsicSize).toBe('');
+    expect(renderedSkeletonCounts).toEqual([2, 1]);
     expect(observerCount).toBe(1);
   } finally {
     globalThis.IntersectionObserver = originalIntersectionObserver;

--- a/src/component/base/__tests__/DraftEditor.react-test.tsx
+++ b/src/component/base/__tests__/DraftEditor.react-test.tsx
@@ -18,6 +18,7 @@ import DraftEditor from '../DraftEditor.react';
 import {createRoot, Root} from 'react-dom/client';
 import {flushSync} from 'react-dom';
 import {createFromText} from '../../../model/immutable/ContentState';
+import {supportsBlockSkeletonRendering} from '../../hooks/useDraftEditorBlockSkeleton';
 
 let container: HTMLElement;
 let root: Root;
@@ -406,6 +407,7 @@ test('renders full blocks when native scroll anchoring is unsupported', () => {
     value: {supports: () => false},
   });
   try {
+    expect(supportsBlockSkeletonRendering()).toBe(false);
     editorState = createWithContent(createFromText('zero\none\ntwo'));
     flushSync(() => {
       root.render(

--- a/src/component/base/__tests__/DraftEditor.react-test.tsx
+++ b/src/component/base/__tests__/DraftEditor.react-test.tsx
@@ -9,10 +9,15 @@
  */
 
 import React from 'react';
-import {createEmpty, EditorState} from '../../../model/immutable/EditorState';
+import {
+  createEmpty,
+  createWithContent,
+  EditorState,
+} from '../../../model/immutable/EditorState';
 import DraftEditor from '../DraftEditor.react';
 import {createRoot, Root} from 'react-dom/client';
 import {flushSync} from 'react-dom';
+import {createFromText} from '../../../model/immutable/ContentState';
 
 let container: HTMLElement;
 let root: Root;
@@ -70,6 +75,127 @@ test('must has editorKey same as props', () => {
   const editorInstance = editorRef.current;
   expect(editorInstance).toBeTruthy();
   expect(editorInstance?.getEditorKey()).toBe('hash');
+});
+
+test('promotes intersecting skeleton blocks to full rendering', () => {
+  const originalIntersectionObserver = globalThis.IntersectionObserver;
+  let observerCallback: IntersectionObserverCallback | undefined;
+  const observedElements: Element[] = [];
+
+  class MockIntersectionObserver implements IntersectionObserver {
+    readonly root = container;
+    readonly rootMargin = '1200px 0px';
+    readonly thresholds = [0];
+
+    constructor(callback: IntersectionObserverCallback) {
+      observerCallback = callback;
+    }
+
+    disconnect(): void {}
+    observe(target: Element): void {
+      observedElements.push(target);
+    }
+    takeRecords(): IntersectionObserverEntry[] {
+      return [];
+    }
+    unobserve(): void {}
+  }
+
+  globalThis.IntersectionObserver = MockIntersectionObserver;
+  try {
+    editorState = createWithContent(createFromText('zero\none\ntwo'));
+    flushSync(() => {
+      root.render(
+        <DraftEditor
+          editorState={editorState}
+          onChange={() => {}}
+          blockSkeleton={{
+            enabled: true,
+            scrollContainerRef: {current: container},
+          }}
+        />,
+      );
+    });
+
+    expect(observedElements).toHaveLength(3);
+    expect(container.querySelectorAll('[data-block-skeleton]')).toHaveLength(2);
+
+    const secondBlock = observedElements[1];
+    expect(secondBlock).toBeDefined();
+    flushSync(() => {
+      observerCallback?.(
+        [
+          {
+            isIntersecting: true,
+            target: secondBlock,
+          } as IntersectionObserverEntry,
+        ],
+        {} as IntersectionObserver,
+      );
+    });
+
+    expect(container.querySelectorAll('[data-block-skeleton]')).toHaveLength(1);
+  } finally {
+    globalThis.IntersectionObserver = originalIntersectionObserver;
+  }
+});
+
+test('renders newly introduced block keys as skeletons immediately', () => {
+  const originalIntersectionObserver = globalThis.IntersectionObserver;
+
+  class MockIntersectionObserver implements IntersectionObserver {
+    readonly root = container;
+    readonly rootMargin = '1200px 0px';
+    readonly thresholds = [0];
+
+    disconnect(): void {}
+    observe(): void {}
+    takeRecords(): IntersectionObserverEntry[] {
+      return [];
+    }
+    unobserve(): void {}
+  }
+
+  globalThis.IntersectionObserver = MockIntersectionObserver;
+  try {
+    const blockRendererFn = jest.fn(() => null);
+    editorState = createWithContent(createFromText('zero\none'));
+    flushSync(() => {
+      root.render(
+        <DraftEditor
+          editorState={editorState}
+          onChange={() => {}}
+          blockRendererFn={blockRendererFn}
+          blockSkeleton={{
+            enabled: true,
+            scrollContainerRef: {current: container},
+          }}
+        />,
+      );
+    });
+    expect(blockRendererFn).toHaveBeenCalledTimes(1);
+
+    blockRendererFn.mockClear();
+    editorState = createWithContent(createFromText('zero\none\ntwo'));
+    flushSync(() => {
+      root.render(
+        <DraftEditor
+          editorState={editorState}
+          onChange={() => {}}
+          blockRendererFn={blockRendererFn}
+          blockSkeleton={{
+            enabled: true,
+            scrollContainerRef: {current: container},
+          }}
+        />,
+      );
+    });
+
+    expect(container.querySelectorAll('[data-block-skeleton]')).toHaveLength(2);
+    expect(blockRendererFn).toHaveBeenCalledTimes(1);
+  } finally {
+    globalThis.IntersectionObserver = originalIntersectionObserver;
+  }
 });
 
 describe('ariaDescribedBy', () => {

--- a/src/component/base/__tests__/DraftEditor.react-test.tsx
+++ b/src/component/base/__tests__/DraftEditor.react-test.tsx
@@ -198,6 +198,93 @@ test('renders newly introduced block keys as skeletons immediately', () => {
   }
 });
 
+test('selects all content across skeleton blocks', () => {
+  const originalIntersectionObserver = globalThis.IntersectionObserver;
+
+  class MockIntersectionObserver implements IntersectionObserver {
+    readonly root = container;
+    readonly rootMargin = '1200px 0px';
+    readonly thresholds = [0];
+
+    disconnect(): void {}
+    observe(): void {}
+    takeRecords(): IntersectionObserverEntry[] {
+      return [];
+    }
+    unobserve(): void {}
+  }
+
+  globalThis.IntersectionObserver = MockIntersectionObserver;
+  try {
+    editorState = createWithContent(createFromText('zero\none\ntwo'));
+    const onChange = jest.fn();
+    flushSync(() => {
+      root.render(
+        <DraftEditor
+          editorState={editorState}
+          onChange={onChange}
+          blockSkeleton={{
+            enabled: true,
+            scrollContainerRef: {current: container},
+          }}
+        />,
+      );
+    });
+
+    const contentEditable = container.querySelector(
+      '[contenteditable="true"]',
+    );
+    expect(contentEditable).not.toBeNull();
+
+    const event = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      ctrlKey: true,
+      key: 'a',
+      metaKey: true,
+    });
+    Object.defineProperties(event, {
+      keyCode: {value: 65},
+      which: {value: 65},
+    });
+    contentEditable!.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const nextEditorState = onChange.mock.calls[0][0] as EditorState;
+    const blocks = [...nextEditorState.currentContent.blockMap.values()];
+    const firstBlock = blocks[0];
+    const lastBlock = blocks[blocks.length - 1];
+    expect(nextEditorState.selection).toEqual({
+      anchorKey: firstBlock.key,
+      anchorOffset: 0,
+      focusKey: lastBlock.key,
+      focusOffset: lastBlock.text.length,
+      hasFocus: true,
+      isBackward: false,
+    });
+
+    flushSync(() => {
+      root.render(
+        <DraftEditor
+          editorState={nextEditorState}
+          onChange={onChange}
+          blockSkeleton={{
+            enabled: true,
+            scrollContainerRef: {current: container},
+          }}
+        />,
+      );
+    });
+    const renderedBlocks = container.querySelectorAll('[data-block-key]');
+    expect(renderedBlocks[0].hasAttribute('data-block-skeleton')).toBe(false);
+    expect(renderedBlocks[1].hasAttribute('data-block-skeleton')).toBe(true);
+    expect(renderedBlocks[2].hasAttribute('data-block-skeleton')).toBe(false);
+  } finally {
+    globalThis.IntersectionObserver = originalIntersectionObserver;
+  }
+});
+
 describe('ariaDescribedBy', () => {
   function getProps(elem: React.ReactElement): Element {
     flushSync(() => {

--- a/src/component/base/__tests__/DraftEditor.react-test.tsx
+++ b/src/component/base/__tests__/DraftEditor.react-test.tsx
@@ -84,7 +84,7 @@ test('promotes intersecting skeleton blocks to full rendering', () => {
 
   class MockIntersectionObserver implements IntersectionObserver {
     readonly root = container;
-    readonly rootMargin = '1200px 0px';
+    readonly rootMargin = '500px 0px';
     readonly thresholds = [0];
 
     constructor(callback: IntersectionObserverCallback) {
@@ -145,7 +145,7 @@ test('renders newly introduced block keys as skeletons immediately', () => {
 
   class MockIntersectionObserver implements IntersectionObserver {
     readonly root = container;
-    readonly rootMargin = '1200px 0px';
+    readonly rootMargin = '500px 0px';
     readonly thresholds = [0];
 
     disconnect(): void {}
@@ -203,7 +203,7 @@ test('selects all content across skeleton blocks', () => {
 
   class MockIntersectionObserver implements IntersectionObserver {
     readonly root = container;
-    readonly rootMargin = '1200px 0px';
+    readonly rootMargin = '500px 0px';
     readonly thresholds = [0];
 
     disconnect(): void {}

--- a/src/component/base/__tests__/DraftEditor.react-test.tsx
+++ b/src/component/base/__tests__/DraftEditor.react-test.tsx
@@ -111,6 +111,10 @@ test('promotes intersecting skeleton blocks to full rendering', () => {
         <DraftEditor
           editorState={editorState}
           onChange={() => {}}
+          blockStyleFn={() => ({
+            containIntrinsicSize: '1px 20px',
+            contentVisibility: 'auto',
+          })}
           blockSkeleton={{
             enabled: true,
             scrollContainerRef: {current: container},
@@ -125,6 +129,10 @@ test('promotes intersecting skeleton blocks to full rendering', () => {
 
     const secondBlock = observedElements[1];
     expect(secondBlock).toBeDefined();
+    expect((secondBlock as HTMLElement).style.contentVisibility).toBe('auto');
+    expect((secondBlock as HTMLElement).style.containIntrinsicSize).toBe(
+      '1px 20px',
+    );
     flushSync(() => {
       observerCallback?.(
         [
@@ -138,6 +146,10 @@ test('promotes intersecting skeleton blocks to full rendering', () => {
     });
 
     expect(container.querySelectorAll('[data-block-skeleton]')).toHaveLength(1);
+    expect((secondBlock as HTMLElement).style.contentVisibility).toBe(
+      'visible',
+    );
+    expect((secondBlock as HTMLElement).style.containIntrinsicSize).toBe('');
     expect(observerCount).toBe(1);
   } finally {
     globalThis.IntersectionObserver = originalIntersectionObserver;

--- a/src/component/base/__tests__/DraftEditor.react-test.tsx
+++ b/src/component/base/__tests__/DraftEditor.react-test.tsx
@@ -80,6 +80,7 @@ test('must has editorKey same as props', () => {
 test('promotes intersecting skeleton blocks to full rendering', () => {
   const originalIntersectionObserver = globalThis.IntersectionObserver;
   let observerCallback: IntersectionObserverCallback | undefined;
+  let observerCount = 0;
   const observedElements: Element[] = [];
 
   class MockIntersectionObserver implements IntersectionObserver {
@@ -88,6 +89,7 @@ test('promotes intersecting skeleton blocks to full rendering', () => {
     readonly thresholds = [0];
 
     constructor(callback: IntersectionObserverCallback) {
+      observerCount++;
       observerCallback = callback;
     }
 
@@ -118,6 +120,7 @@ test('promotes intersecting skeleton blocks to full rendering', () => {
     });
 
     expect(observedElements).toHaveLength(3);
+    expect(observerCount).toBe(1);
     expect(container.querySelectorAll('[data-block-skeleton]')).toHaveLength(2);
 
     const secondBlock = observedElements[1];
@@ -135,6 +138,7 @@ test('promotes intersecting skeleton blocks to full rendering', () => {
     });
 
     expect(container.querySelectorAll('[data-block-skeleton]')).toHaveLength(1);
+    expect(observerCount).toBe(1);
   } finally {
     globalThis.IntersectionObserver = originalIntersectionObserver;
   }
@@ -142,6 +146,9 @@ test('promotes intersecting skeleton blocks to full rendering', () => {
 
 test('renders newly introduced block keys as skeletons immediately', () => {
   const originalIntersectionObserver = globalThis.IntersectionObserver;
+  const originalMutationObserver = globalThis.MutationObserver;
+  const observedElements: Element[] = [];
+  let mutationCallback: MutationCallback | undefined;
 
   class MockIntersectionObserver implements IntersectionObserver {
     readonly root = container;
@@ -149,14 +156,29 @@ test('renders newly introduced block keys as skeletons immediately', () => {
     readonly thresholds = [0];
 
     disconnect(): void {}
-    observe(): void {}
+    observe(target: Element): void {
+      observedElements.push(target);
+    }
     takeRecords(): IntersectionObserverEntry[] {
       return [];
     }
     unobserve(): void {}
   }
 
+  class MockMutationObserver implements MutationObserver {
+    constructor(callback: MutationCallback) {
+      mutationCallback = callback;
+    }
+
+    disconnect(): void {}
+    observe(): void {}
+    takeRecords(): MutationRecord[] {
+      return [];
+    }
+  }
+
   globalThis.IntersectionObserver = MockIntersectionObserver;
+  globalThis.MutationObserver = MockMutationObserver;
   try {
     const blockRendererFn = jest.fn(() => null);
     editorState = createWithContent(createFromText('zero\none'));
@@ -193,12 +215,26 @@ test('renders newly introduced block keys as skeletons immediately', () => {
 
     expect(container.querySelectorAll('[data-block-skeleton]')).toHaveLength(2);
     expect(blockRendererFn).toHaveBeenCalledTimes(1);
+
+    const newBlock = container.querySelectorAll('[data-block-key]')[2];
+    mutationCallback?.(
+      [
+        ({
+          addedNodes: [newBlock],
+          removedNodes: [],
+        } as unknown) as MutationRecord,
+      ],
+      {} as MutationObserver,
+    );
+    expect(observedElements).toContain(newBlock);
   } finally {
     globalThis.IntersectionObserver = originalIntersectionObserver;
+    globalThis.MutationObserver = originalMutationObserver;
   }
 });
 
-test('selects all content across skeleton blocks', () => {
+test('renders full blocks when native scroll anchoring is unsupported', () => {
+  const originalCSS = globalThis.CSS;
   const originalIntersectionObserver = globalThis.IntersectionObserver;
 
   class MockIntersectionObserver implements IntersectionObserver {
@@ -215,14 +251,17 @@ test('selects all content across skeleton blocks', () => {
   }
 
   globalThis.IntersectionObserver = MockIntersectionObserver;
+  Object.defineProperty(globalThis, 'CSS', {
+    configurable: true,
+    value: {supports: () => false},
+  });
   try {
     editorState = createWithContent(createFromText('zero\none\ntwo'));
-    const onChange = jest.fn();
     flushSync(() => {
       root.render(
         <DraftEditor
           editorState={editorState}
-          onChange={onChange}
+          onChange={() => {}}
           blockSkeleton={{
             enabled: true,
             scrollContainerRef: {current: container},
@@ -231,57 +270,13 @@ test('selects all content across skeleton blocks', () => {
       );
     });
 
-    const contentEditable = container.querySelector(
-      '[contenteditable="true"]',
-    );
-    expect(contentEditable).not.toBeNull();
-
-    const event = new KeyboardEvent('keydown', {
-      bubbles: true,
-      cancelable: true,
-      ctrlKey: true,
-      key: 'a',
-      metaKey: true,
-    });
-    Object.defineProperties(event, {
-      keyCode: {value: 65},
-      which: {value: 65},
-    });
-    contentEditable!.dispatchEvent(event);
-
-    expect(event.defaultPrevented).toBe(true);
-    expect(onChange).toHaveBeenCalledTimes(1);
-    const nextEditorState = onChange.mock.calls[0][0] as EditorState;
-    const blocks = [...nextEditorState.currentContent.blockMap.values()];
-    const firstBlock = blocks[0];
-    const lastBlock = blocks[blocks.length - 1];
-    expect(nextEditorState.selection).toEqual({
-      anchorKey: firstBlock.key,
-      anchorOffset: 0,
-      focusKey: lastBlock.key,
-      focusOffset: lastBlock.text.length,
-      hasFocus: true,
-      isBackward: false,
-    });
-
-    flushSync(() => {
-      root.render(
-        <DraftEditor
-          editorState={nextEditorState}
-          onChange={onChange}
-          blockSkeleton={{
-            enabled: true,
-            scrollContainerRef: {current: container},
-          }}
-        />,
-      );
-    });
-    const renderedBlocks = container.querySelectorAll('[data-block-key]');
-    expect(renderedBlocks[0].hasAttribute('data-block-skeleton')).toBe(false);
-    expect(renderedBlocks[1].hasAttribute('data-block-skeleton')).toBe(true);
-    expect(renderedBlocks[2].hasAttribute('data-block-skeleton')).toBe(false);
+    expect(container.querySelectorAll('[data-block-skeleton]')).toHaveLength(0);
   } finally {
     globalThis.IntersectionObserver = originalIntersectionObserver;
+    Object.defineProperty(globalThis, 'CSS', {
+      configurable: true,
+      value: originalCSS,
+    });
   }
 });
 

--- a/src/component/contents/DraftDecoratorDOMAnchors.react.tsx
+++ b/src/component/contents/DraftDecoratorDOMAnchors.react.tsx
@@ -1,0 +1,16 @@
+import React, {ReactNode} from 'react';
+
+export default function wrapInDOMAnchors(
+  children: ReactNode,
+  anchorIds: readonly string[] | undefined,
+): ReactNode {
+  let result = children;
+  for (const anchorId of anchorIds ?? []) {
+    result = (
+      <span id={anchorId} key={anchorId}>
+        {result}
+      </span>
+    );
+  }
+  return result;
+}

--- a/src/component/contents/DraftEditorBlock.react.tsx
+++ b/src/component/contents/DraftEditorBlock.react.tsx
@@ -39,6 +39,7 @@ import {
 import {DraftDecoratorComponentProps} from '../../model/decorators/DraftDecorator';
 import {BlockNode} from '../../model/immutable/BlockNode';
 import {DOMSelectionUpdateFn} from '../selection/DOMSelectionUpdate';
+import wrapInDOMAnchors from './DraftDecoratorDOMAnchors.react';
 
 const DEFAULT_SCROLL_BUFFER = 10;
 
@@ -360,11 +361,23 @@ export default class DraftEditorBlock extends React.Component<Props> {
         offsetKey: decoratorOffsetKey,
       };
 
-      return (
+      const anchorIds = decorator.getDOMAnchorIdsForRange?.({
+        block,
+        contentState: this.props.contentState,
+        decoratorKey,
+        start,
+        end,
+        entityKey,
+      });
+
+      const decoratedRange = (
         <DecoratorComponent {...decoratorProps} {...commonProps}>
           {leaves}
         </DecoratorComponent>
       );
+      return anchorIds?.length
+        ? wrapInDOMAnchors(decoratedRange, anchorIds)
+        : decoratedRange;
     });
   }
 

--- a/src/component/contents/DraftEditorBlock.react.tsx
+++ b/src/component/contents/DraftEditorBlock.react.tsx
@@ -100,6 +100,16 @@ const getNodeScrollTopAndBottom = (
  * A `DraftEditorBlock` is able to render a given `ContentBlock` to its
  * appropriate decorator and inline style components.
  */
+export function getDraftEditorBlockClassName(
+  direction: BidiDirection,
+): string {
+  return cx({
+    'public/DraftStyleDefault/block': true,
+    'public/DraftStyleDefault/ltr': direction === 'LTR',
+    'public/DraftStyleDefault/rtl': direction === 'RTL',
+  });
+}
+
 export default class DraftEditorBlock extends React.Component<Props> {
   _node: HTMLDivElement | null = null;
 
@@ -362,11 +372,7 @@ export default class DraftEditorBlock extends React.Component<Props> {
 
   render(): React.ReactNode {
     const {direction, offsetKey} = this.props;
-    const className = cx({
-      'public/DraftStyleDefault/block': true,
-      'public/DraftStyleDefault/ltr': direction === 'LTR',
-      'public/DraftStyleDefault/rtl': direction === 'RTL',
-    });
+    const className = getDraftEditorBlockClassName(direction);
 
     return (
       <div

--- a/src/component/contents/DraftEditorBlock.react.tsx
+++ b/src/component/contents/DraftEditorBlock.react.tsx
@@ -100,9 +100,7 @@ const getNodeScrollTopAndBottom = (
  * A `DraftEditorBlock` is able to render a given `ContentBlock` to its
  * appropriate decorator and inline style components.
  */
-export function getDraftEditorBlockClassName(
-  direction: BidiDirection,
-): string {
+function getDraftEditorBlockClassName(direction: BidiDirection): string {
   return cx({
     'public/DraftStyleDefault/block': true,
     'public/DraftStyleDefault/ltr': direction === 'LTR',

--- a/src/component/contents/DraftEditorContents-core.react.tsx
+++ b/src/component/contents/DraftEditorContents-core.react.tsx
@@ -17,9 +17,7 @@ import cx from 'fbjs/lib/cx';
 import joinClasses from 'fbjs/lib/joinClasses';
 import {nullthrows} from '../../fbjs/nullthrows';
 import DraftOffsetKey from '../selection/DraftOffsetKey';
-import DraftEditorBlock, {
-  getDraftEditorBlockClassName,
-} from './DraftEditorBlock.react';
+import DraftEditorBlock from './DraftEditorBlock.react';
 import {BlockNode} from '../../model/immutable/BlockNode';
 import {getEntityAt} from '../../model/immutable/ContentBlock';
 import {DraftEditorBlockSkeletonState} from '../hooks/useDraftEditorBlockSkeleton';
@@ -353,12 +351,15 @@ export default class DraftEditorContents extends React.Component<Props> {
       if (blockSkeleton && !blockSkeleton.fullBlockKeys.has(key)) {
         childProps = {
           ...childProps,
-          className: joinClasses(
-            className,
-            getDraftEditorBlockClassName(direction),
-          ),
           contentEditable: false,
           'data-block-skeleton': true,
+          style: {
+            ...inlineStyle,
+            direction: direction === 'RTL' ? 'rtl' : 'ltr',
+            position: 'relative',
+            textAlign: direction === 'RTL' ? 'right' : 'left',
+            whiteSpace: 'pre-wrap',
+          },
           suppressContentEditableWarning: true,
         };
         const tree = decorator?.getSkeletonAttributesForRange

--- a/src/component/contents/DraftEditorContents-core.react.tsx
+++ b/src/component/contents/DraftEditorContents-core.react.tsx
@@ -17,8 +17,12 @@ import cx from 'fbjs/lib/cx';
 import joinClasses from 'fbjs/lib/joinClasses';
 import {nullthrows} from '../../fbjs/nullthrows';
 import DraftOffsetKey from '../selection/DraftOffsetKey';
-import DraftEditorBlock from './DraftEditorBlock.react';
+import DraftEditorBlock, {
+  getDraftEditorBlockClassName,
+} from './DraftEditorBlock.react';
 import {BlockNode} from '../../model/immutable/BlockNode';
+import {getEntityAt} from '../../model/immutable/ContentBlock';
+import {DraftEditorBlockSkeletonState} from '../hooks/useDraftEditorBlockSkeleton';
 import {
   DOMLocation,
   DOMSelectionUpdateFn,
@@ -30,11 +34,13 @@ type Props = {
   blockRenderMap: DraftBlockRenderMap;
   blockRendererFn: (block: BlockNode) => Record<string, any> | null;
   blockStyleFn?: (block: BlockNode) => string | CSSProperties | undefined;
+  blockSkeleton?: DraftEditorBlockSkeletonState;
   customStyleFn?: (
     style: DraftInlineStyle,
     block: BlockNode,
   ) => Record<string, any> | null;
   customStyleMap?: Record<string, any>;
+  contentsRef?: (node: HTMLDivElement | null) => void;
   editorKey?: string;
   editorState: EditorState;
   preventScroll?: boolean;
@@ -77,6 +83,63 @@ const getListItemClasses = (
   });
 };
 
+function renderSkeletonChildren({
+  block,
+  contentState,
+  decorator,
+  tree,
+}: {
+  block: BlockNode;
+  contentState: EditorState['currentContent'];
+  decorator: EditorState['decorator'];
+  tree: ReturnType<typeof getBlockTree>;
+}): ReactNode {
+  if (!decorator?.getSkeletonAttributesForRange) {
+    return block.text || <br data-text={true} />;
+  }
+
+  const children: ReactNode[] = [];
+  let plainTextStart = 0;
+  for (const range of tree) {
+    if (range.decoratorKey === null) {
+      continue;
+    }
+    const skeletonAttributes = decorator.getSkeletonAttributesForRange({
+      block,
+      contentState,
+      decoratorKey: range.decoratorKey,
+      start: range.start,
+      end: range.end,
+      entityKey: getEntityAt(block, range.start),
+    });
+    if (!skeletonAttributes?.length) {
+      continue;
+    }
+
+    if (plainTextStart < range.start) {
+      children.push(block.text.slice(plainTextStart, range.start));
+    }
+    let decoratedText: ReactNode = block.text.slice(range.start, range.end);
+    for (const [index, attributes] of skeletonAttributes.entries()) {
+      decoratedText = React.createElement(
+        'span',
+        {
+          ...attributes,
+          key: `${range.start}-${index}`,
+        },
+        decoratedText,
+      );
+    }
+    children.push(decoratedText);
+    plainTextStart = range.end;
+  }
+
+  if (plainTextStart < block.text.length) {
+    children.push(block.text.slice(plainTextStart));
+  }
+  return children.length ? children : block.text || <br data-text={true} />;
+}
+
 /**
  * `DraftEditorContents` is the container component for all block components
  * rendered for a `DraftEditor`. It is optimized to aggressively avoid
@@ -91,7 +154,7 @@ export default class DraftEditorContents extends React.Component<Props> {
     anchor?: DOMLocation;
     focus?: DOMLocation;
   } = {anchor: undefined, focus: undefined};
-  private ref = React.createRef<HTMLDivElement>();
+  private contentsElement: HTMLDivElement | null = null;
 
   shouldComponentUpdate(nextProps: Props): boolean {
     const prevEditorState = this.props.editorState;
@@ -128,6 +191,13 @@ export default class DraftEditorContents extends React.Component<Props> {
     const wasComposing = prevEditorState.inCompositionMode;
     const nowComposing = nextEditorState.inCompositionMode;
 
+    if (
+      !(wasComposing && nowComposing) &&
+      this.props.blockSkeleton !== nextProps.blockSkeleton
+    ) {
+      return true;
+    }
+
     // If the state is unchanged or we're currently rendering a natively
     // rendered state, there's nothing new to be done.
     if (
@@ -158,7 +228,7 @@ export default class DraftEditorContents extends React.Component<Props> {
   }
 
   _updateDomSelection() {
-    const thisNode = this.ref.current;
+    const thisNode = this.contentsElement;
     if (thisNode) {
       const selection = getDOMSelection(thisNode);
       if (selection) {
@@ -182,6 +252,11 @@ export default class DraftEditorContents extends React.Component<Props> {
     this.scheduledDomSelectionUpdates[type] = loc;
   };
 
+  _setContentsRef = (node: HTMLDivElement | null) => {
+    this.contentsElement = node;
+    this.props.contentsRef?.(node);
+  };
+
   render(): React.ReactNode {
     // Reset the DOM selection updates before each render
     this._clearDomSelectionUpdates();
@@ -190,6 +265,7 @@ export default class DraftEditorContents extends React.Component<Props> {
       blockRenderMap,
       blockRendererFn,
       blockStyleFn,
+      blockSkeleton,
       customStyleMap,
       customStyleFn,
       editorState,
@@ -225,40 +301,10 @@ export default class DraftEditorContents extends React.Component<Props> {
       const key = block.key;
       const blockType = block.type;
 
-      const customRenderer = blockRendererFn(block);
-      let CustomComponent, customProps, customEditable;
-      if (customRenderer) {
-        CustomComponent = customRenderer.component;
-        customProps = customRenderer.props;
-        customEditable = customRenderer.editable;
-      }
-
       const direction = textDirectionality
         ? textDirectionality
         : directionMap.get(key);
       const offsetKey = DraftOffsetKey.encode(key, 0, 0);
-      const componentProps = {
-        contentState: content,
-        block,
-        blockProps: customProps,
-        blockStyleFn,
-        customStyleMap,
-        customStyleFn,
-        decorator,
-        direction,
-        forceSelection,
-        offsetKey,
-        preventScroll,
-        selection,
-        tree: getBlockTree(editorState, key),
-        scrollUpThreshold,
-        scrollUpHeight,
-        scrollDownThreshold,
-        scrollDownHeight,
-        scheduleDomSelectionUpdate: this.props.globalDomSelectionUpdate
-          ? this.scheduleDomSelectionUpdate
-          : undefined,
-      };
 
       const configForType =
         blockRenderMap[blockType] || blockRenderMap['unstyled'];
@@ -293,32 +339,88 @@ export default class DraftEditorContents extends React.Component<Props> {
         );
       }
 
-      const Component = CustomComponent || DraftEditorBlock;
       let childProps: Record<string, any> = {
         className,
         'data-block': true,
+        'data-block-key': key,
         'data-editor': editorKey,
         'data-offset-key': offsetKey,
         id: `block-${key}`,
         key,
         style: inlineStyle,
       };
-      if (customEditable !== undefined) {
+      let child: ReactNode;
+      if (blockSkeleton && !blockSkeleton.fullBlockKeys.has(key)) {
         childProps = {
           ...childProps,
-          contentEditable: customEditable,
+          className: joinClasses(
+            className,
+            getDraftEditorBlockClassName(direction),
+          ),
+          contentEditable: false,
+          'data-block-skeleton': true,
           suppressContentEditableWarning: true,
         };
+        const tree = decorator?.getSkeletonAttributesForRange
+          ? getBlockTree(editorState, key)
+          : [];
+        child = React.createElement(
+          Element,
+          childProps,
+          renderSkeletonChildren({
+            block,
+            contentState: content,
+            decorator,
+            tree,
+          }),
+        );
+      } else {
+        const customRenderer = blockRendererFn(block);
+        let CustomComponent, customProps, customEditable;
+        if (customRenderer) {
+          CustomComponent = customRenderer.component;
+          customProps = customRenderer.props;
+          customEditable = customRenderer.editable;
+        }
+        const componentProps = {
+          contentState: content,
+          block,
+          blockProps: customProps,
+          blockStyleFn,
+          customStyleMap,
+          customStyleFn,
+          decorator,
+          direction,
+          forceSelection,
+          offsetKey,
+          preventScroll,
+          selection,
+          tree: getBlockTree(editorState, key),
+          scrollUpThreshold,
+          scrollUpHeight,
+          scrollDownThreshold,
+          scrollDownHeight,
+          scheduleDomSelectionUpdate: this.props.globalDomSelectionUpdate
+            ? this.scheduleDomSelectionUpdate
+            : undefined,
+        };
+        const Component = CustomComponent || DraftEditorBlock;
+        if (customEditable !== undefined) {
+          childProps = {
+            ...childProps,
+            contentEditable: customEditable,
+            suppressContentEditableWarning: true,
+          };
+        }
+        child = React.createElement(
+          Element,
+          childProps,
+          /* $FlowFixMe(>=0.112.0 site=www,mobile) This comment suppresses an
+           * error found when Flow v0.112 was deployed. To see the error delete
+           * this comment and run Flow. */
+          <Component {...componentProps} key={key} />,
+        );
       }
-
-      const child = React.createElement(
-        Element,
-        childProps,
-        /* $FlowFixMe(>=0.112.0 site=www,mobile) This comment suppresses an
-         * error found when Flow v0.112 was deployed. To see the error delete
-         * this comment and run Flow. */
-        <Component {...componentProps} key={key} />,
-      );
 
       processedBlocks.push({
         block: child,
@@ -364,7 +466,7 @@ export default class DraftEditorContents extends React.Component<Props> {
     }
 
     return (
-      <div data-contents="true" ref={this.ref}>
+      <div data-contents="true" ref={this._setContentsRef}>
         {outputBlocks}
       </div>
     );

--- a/src/component/contents/DraftEditorContents-core.react.tsx
+++ b/src/component/contents/DraftEditorContents-core.react.tsx
@@ -318,17 +318,6 @@ export default class DraftEditorContents extends React.Component<Props> {
 
       const shouldRenderSkeleton =
         blockSkeleton && !blockSkeleton.fullBlockKeys.has(key);
-      if (
-        blockSkeleton &&
-        !shouldRenderSkeleton &&
-        inlineStyle?.contentVisibility === 'auto'
-      ) {
-        inlineStyle = {
-          ...inlineStyle,
-          containIntrinsicSize: undefined,
-          contentVisibility: 'visible',
-        };
-      }
 
       // List items are special snowflakes, since we handle nesting and
       // counters manually.

--- a/src/component/contents/DraftEditorContents-core.react.tsx
+++ b/src/component/contents/DraftEditorContents-core.react.tsx
@@ -316,6 +316,20 @@ export default class DraftEditorContents extends React.Component<Props> {
         }
       }
 
+      const shouldRenderSkeleton =
+        blockSkeleton && !blockSkeleton.fullBlockKeys.has(key);
+      if (
+        blockSkeleton &&
+        !shouldRenderSkeleton &&
+        inlineStyle?.contentVisibility === 'auto'
+      ) {
+        inlineStyle = {
+          ...inlineStyle,
+          containIntrinsicSize: undefined,
+          contentVisibility: 'visible',
+        };
+      }
+
       // List items are special snowflakes, since we handle nesting and
       // counters manually.
       if (Element === 'li') {
@@ -340,7 +354,7 @@ export default class DraftEditorContents extends React.Component<Props> {
         style: inlineStyle,
       };
       let child: ReactNode;
-      if (blockSkeleton && !blockSkeleton.fullBlockKeys.has(key)) {
+      if (shouldRenderSkeleton) {
         childProps = {
           ...childProps,
           'data-block-skeleton': true,

--- a/src/component/contents/DraftEditorContents-core.react.tsx
+++ b/src/component/contents/DraftEditorContents-core.react.tsx
@@ -21,6 +21,7 @@ import DraftEditorBlock from './DraftEditorBlock.react';
 import {BlockNode} from '../../model/immutable/BlockNode';
 import {getEntityAt} from '../../model/immutable/ContentBlock';
 import {DraftEditorBlockSkeletonState} from '../hooks/useDraftEditorBlockSkeleton';
+import wrapInDOMAnchors from './DraftDecoratorDOMAnchors.react';
 import {
   DOMLocation,
   DOMSelectionUpdateFn,
@@ -92,7 +93,7 @@ function renderSkeletonChildren({
   decorator: EditorState['decorator'];
   tree: ReturnType<typeof getBlockTree>;
 }): ReactNode {
-  if (!decorator?.getSkeletonAttributesForRange) {
+  if (!decorator?.getDOMAnchorIdsForRange) {
     return block.text || <br data-text={true} />;
   }
 
@@ -102,7 +103,7 @@ function renderSkeletonChildren({
     if (range.decoratorKey === null) {
       continue;
     }
-    const skeletonAttributes = decorator.getSkeletonAttributesForRange({
+    const anchorIds = decorator.getDOMAnchorIdsForRange({
       block,
       contentState,
       decoratorKey: range.decoratorKey,
@@ -110,25 +111,16 @@ function renderSkeletonChildren({
       end: range.end,
       entityKey: getEntityAt(block, range.start),
     });
-    if (!skeletonAttributes?.length) {
+    if (!anchorIds?.length) {
       continue;
     }
 
     if (plainTextStart < range.start) {
       children.push(block.text.slice(plainTextStart, range.start));
     }
-    let decoratedText: ReactNode = block.text.slice(range.start, range.end);
-    for (const [index, attributes] of skeletonAttributes.entries()) {
-      decoratedText = React.createElement(
-        'span',
-        {
-          ...attributes,
-          key: `${range.start}-${index}`,
-        },
-        decoratedText,
-      );
-    }
-    children.push(decoratedText);
+    children.push(
+      wrapInDOMAnchors(block.text.slice(range.start, range.end), anchorIds),
+    );
     plainTextStart = range.end;
   }
 
@@ -351,7 +343,6 @@ export default class DraftEditorContents extends React.Component<Props> {
       if (blockSkeleton && !blockSkeleton.fullBlockKeys.has(key)) {
         childProps = {
           ...childProps,
-          contentEditable: false,
           'data-block-skeleton': true,
           style: {
             ...inlineStyle,
@@ -360,9 +351,8 @@ export default class DraftEditorContents extends React.Component<Props> {
             textAlign: direction === 'RTL' ? 'right' : 'left',
             whiteSpace: 'pre-wrap',
           },
-          suppressContentEditableWarning: true,
         };
-        const tree = decorator?.getSkeletonAttributesForRange
+        const tree = decorator?.getDOMAnchorIdsForRange
           ? getBlockTree(editorState, key)
           : [];
         child = React.createElement(

--- a/src/component/contents/DraftEditorSkeletonContents.react.tsx
+++ b/src/component/contents/DraftEditorSkeletonContents.react.tsx
@@ -21,6 +21,7 @@ export default function DraftEditorSkeletonContents({
     enabled: blockSkeleton?.enabled ?? false,
     editorState: contentsProps.editorState,
     contentsElement,
+    onBlockSkeletonsRendered: blockSkeleton?.onBlockSkeletonsRendered,
     scrollContainerRef: blockSkeleton?.scrollContainerRef,
   });
 

--- a/src/component/contents/DraftEditorSkeletonContents.react.tsx
+++ b/src/component/contents/DraftEditorSkeletonContents.react.tsx
@@ -1,0 +1,35 @@
+import React, {useRef} from 'react';
+import {DraftEditorBlockSkeletonOptions} from '../base/DraftEditorProps';
+import DraftEditorContents from './DraftEditorContents-core.react';
+import {useDraftEditorBlockSkeleton} from '../hooks/useDraftEditorBlockSkeleton';
+
+type Props = Omit<
+  React.ComponentProps<typeof DraftEditorContents>,
+  'blockSkeleton'
+> & {
+  blockSkeleton?: DraftEditorBlockSkeletonOptions;
+};
+
+export default function DraftEditorSkeletonContents({
+  blockSkeleton,
+  ...contentsProps
+}: Props): React.ReactNode {
+  const contentsRef = useRef<HTMLDivElement | null>(null);
+  const skeletonState = useDraftEditorBlockSkeleton({
+    enabled: blockSkeleton?.enabled ?? false,
+    editorState: contentsProps.editorState,
+    contentsRef,
+    scrollContainerRef: blockSkeleton?.scrollContainerRef ?? contentsRef,
+    pinnedBlockKeys: blockSkeleton?.pinnedBlockKeys,
+  });
+
+  return (
+    <DraftEditorContents
+      {...contentsProps}
+      blockSkeleton={skeletonState}
+      contentsRef={node => {
+        contentsRef.current = node;
+      }}
+    />
+  );
+}

--- a/src/component/contents/DraftEditorSkeletonContents.react.tsx
+++ b/src/component/contents/DraftEditorSkeletonContents.react.tsx
@@ -20,7 +20,6 @@ export default function DraftEditorSkeletonContents({
     editorState: contentsProps.editorState,
     contentsRef,
     scrollContainerRef: blockSkeleton?.scrollContainerRef ?? contentsRef,
-    pinnedBlockKeys: blockSkeleton?.pinnedBlockKeys,
   });
 
   return (

--- a/src/component/contents/DraftEditorSkeletonContents.react.tsx
+++ b/src/component/contents/DraftEditorSkeletonContents.react.tsx
@@ -1,4 +1,4 @@
-import React, {useRef} from 'react';
+import React, {useState} from 'react';
 import {DraftEditorBlockSkeletonOptions} from '../base/DraftEditorProps';
 import DraftEditorContents from './DraftEditorContents-core.react';
 import {useDraftEditorBlockSkeleton} from '../hooks/useDraftEditorBlockSkeleton';
@@ -14,21 +14,21 @@ export default function DraftEditorSkeletonContents({
   blockSkeleton,
   ...contentsProps
 }: Props): React.ReactNode {
-  const contentsRef = useRef<HTMLDivElement | null>(null);
+  const [contentsElement, setContentsElement] = useState<HTMLDivElement | null>(
+    null,
+  );
   const skeletonState = useDraftEditorBlockSkeleton({
     enabled: blockSkeleton?.enabled ?? false,
     editorState: contentsProps.editorState,
-    contentsRef,
-    scrollContainerRef: blockSkeleton?.scrollContainerRef ?? contentsRef,
+    contentsElement,
+    scrollContainerRef: blockSkeleton?.scrollContainerRef,
   });
 
   return (
     <DraftEditorContents
       {...contentsProps}
       blockSkeleton={skeletonState}
-      contentsRef={node => {
-        contentsRef.current = node;
-      }}
+      contentsRef={setContentsElement}
     />
   );
 }

--- a/src/component/contents/__tests__/DraftEditorContents.react-test.tsx
+++ b/src/component/contents/__tests__/DraftEditorContents.react-test.tsx
@@ -146,6 +146,7 @@ test('renders offscreen blocks as text skeletons with persistent decorator attri
         editorState={editorState}
         blockRenderMap={DefaultDraftBlockRenderMap}
         blockRendererFn={blockRendererFn}
+        blockStyleFn={() => ({marginBottom: '16px'})}
         blockSkeleton={{
           fullBlockKeys: new Set(fullBlock ? [fullBlock.key] : []),
         }}
@@ -167,10 +168,15 @@ test('renders offscreen blocks as text skeletons with persistent decorator attri
   }
 
   for (const block of blocks.slice(1)) {
-    const skeleton = container.querySelector(
+    const skeleton = container.querySelector<HTMLElement>(
       `[data-block-key="${block.key}"]`,
     );
     expect(skeleton?.getAttribute('contenteditable')).toBe('false');
+    expect(skeleton?.classList.contains('public-DraftStyleDefault-block')).toBe(
+      false,
+    );
+    expect(skeleton?.style.marginBottom).toBe('16px');
+    expect(skeleton?.style.whiteSpace).toBe('pre-wrap');
     expect(
       skeleton?.querySelector(`#persistent-${block.key}`)?.textContent,
     ).toBe(block.text.slice(0, 3));

--- a/src/component/contents/__tests__/DraftEditorContents.react-test.tsx
+++ b/src/component/contents/__tests__/DraftEditorContents.react-test.tsx
@@ -119,7 +119,7 @@ test('defaults to "unstyled" block type for unknown block types', () => {
   }).not.toThrow();
 });
 
-test('renders offscreen blocks as text skeletons with persistent decorator attributes', () => {
+test('renders offscreen blocks as text skeletons with persistent DOM anchors', () => {
   const decorator: DraftDecoratorType = {
     getDecorations: block =>
       block.text.split('').map((_, index) => (index < 3 ? 'linked' : null)),
@@ -128,9 +128,7 @@ test('renders offscreen blocks as text skeletons with persistent decorator attri
         return <strong data-full-decoration={true}>{children}</strong>;
       },
     getPropsForKey: () => null,
-    getSkeletonAttributesForRange: ({block}) => [
-      {id: `persistent-${block.key}`},
-    ],
+    getDOMAnchorIdsForRange: ({block}) => [`persistent-${block.key}`],
   };
   const editorState = createWithContent(
     createFromText('zero\none\ntwo'),
@@ -161,24 +159,22 @@ test('renders offscreen blocks as text skeletons with persistent decorator attri
   expect(blockRendererFn).toHaveBeenCalledTimes(1);
 
   for (const block of blocks) {
-    const skeleton = container.querySelector(
-      `[data-block-key="${block.key}"]`,
-    );
+    const skeleton = container.querySelector(`[data-block-key="${block.key}"]`);
     expect(skeleton?.id).toBe(`block-${block.key}`);
+    expect(
+      skeleton?.querySelector(`#persistent-${block.key}`)?.textContent,
+    ).toBe(block.text.slice(0, 3));
   }
 
   for (const block of blocks.slice(1)) {
     const skeleton = container.querySelector<HTMLElement>(
       `[data-block-key="${block.key}"]`,
     );
-    expect(skeleton?.getAttribute('contenteditable')).toBe('false');
+    expect(skeleton?.hasAttribute('contenteditable')).toBe(false);
     expect(skeleton?.classList.contains('public-DraftStyleDefault-block')).toBe(
       false,
     );
     expect(skeleton?.style.marginBottom).toBe('16px');
     expect(skeleton?.style.whiteSpace).toBe('pre-wrap');
-    expect(
-      skeleton?.querySelector(`#persistent-${block.key}`)?.textContent,
-    ).toBe(block.text.slice(0, 3));
   }
 });

--- a/src/component/contents/__tests__/DraftEditorContents.react-test.tsx
+++ b/src/component/contents/__tests__/DraftEditorContents.react-test.tsx
@@ -8,13 +8,21 @@
  * @format
  */
 
-import {createEmpty, EditorState} from '../../../model/immutable/EditorState';
+import {
+  createEmpty,
+  createWithContent,
+  EditorState,
+} from '../../../model/immutable/EditorState';
 
 import React from 'react';
 import RichTextEditorUtil from '../../../model/modifier/RichTextEditorUtil';
 import {createRoot, Root} from 'react-dom/client';
 import {flushSync} from 'react-dom';
 import DraftEditor from '../../base/DraftEditor.react';
+import DraftEditorContents from '../DraftEditorContents-core.react';
+import {createFromText} from '../../../model/immutable/ContentState';
+import {DefaultDraftBlockRenderMap} from '../../../model/immutable/DefaultDraftBlockRenderMap';
+import {DraftDecoratorType} from '../../../model/decorators/DraftDecoratorType';
 
 let container: HTMLElement;
 let root: Root;
@@ -109,4 +117,62 @@ test('defaults to "unstyled" block type for unknown block types', () => {
   expect(() => {
     editorInstance?.toggleCustomBlock();
   }).not.toThrow();
+});
+
+test('renders offscreen blocks as text skeletons with persistent decorator attributes', () => {
+  const decorator: DraftDecoratorType = {
+    getDecorations: block =>
+      block.text.split('').map((_, index) => (index < 3 ? 'linked' : null)),
+    getComponentForKey: () =>
+      function FullDecorator({children}) {
+        return <strong data-full-decoration={true}>{children}</strong>;
+      },
+    getPropsForKey: () => null,
+    getSkeletonAttributesForRange: ({block}) => [
+      {id: `persistent-${block.key}`},
+    ],
+  };
+  const editorState = createWithContent(
+    createFromText('zero\none\ntwo'),
+    decorator,
+  );
+  const blocks = Array.from(editorState.currentContent.blockMap.values());
+  const fullBlock = blocks[0];
+  const blockRendererFn = jest.fn(() => null);
+
+  flushSync(() => {
+    root.render(
+      <DraftEditorContents
+        editorState={editorState}
+        blockRenderMap={DefaultDraftBlockRenderMap}
+        blockRendererFn={blockRendererFn}
+        blockSkeleton={{
+          fullBlockKeys: new Set(fullBlock ? [fullBlock.key] : []),
+        }}
+      />,
+    );
+  });
+
+  expect(container.textContent).toBe('zeroonetwo');
+  expect(container.querySelectorAll('[data-block]')).toHaveLength(3);
+  expect(container.querySelectorAll('[data-block-skeleton]')).toHaveLength(2);
+  expect(container.querySelectorAll('[data-full-decoration]')).toHaveLength(1);
+  expect(blockRendererFn).toHaveBeenCalledTimes(1);
+
+  for (const block of blocks) {
+    const skeleton = container.querySelector(
+      `[data-block-key="${block.key}"]`,
+    );
+    expect(skeleton?.id).toBe(`block-${block.key}`);
+  }
+
+  for (const block of blocks.slice(1)) {
+    const skeleton = container.querySelector(
+      `[data-block-key="${block.key}"]`,
+    );
+    expect(skeleton?.getAttribute('contenteditable')).toBe('false');
+    expect(
+      skeleton?.querySelector(`#persistent-${block.key}`)?.textContent,
+    ).toBe(block.text.slice(0, 3));
+  }
 });

--- a/src/component/handlers/edit/editOnKeyDown.ts
+++ b/src/component/handlers/edit/editOnKeyDown.ts
@@ -15,15 +15,9 @@ import KeyBindingUtil from '../../utils/KeyBindingUtil';
 import {DraftEditorCommand} from '../../../model/constants/DraftEditorCommand';
 import {
   EditorState,
-  forceSelection,
   pushContent,
   redo,
 } from '../../../model/immutable/EditorState';
-import {
-  getFirstBlock,
-  getLastBlock,
-} from '../../../model/immutable/ContentState';
-import {makeSelectionState} from '../../../model/immutable/SelectionState';
 import isEventHandled from '../../utils/isEventHandled';
 import keyCommandPlainDelete from './commands/keyCommandPlainDelete';
 import keyCommandDeleteWord from './commands/keyCommandDeleteWord';
@@ -39,7 +33,7 @@ import DraftEditor from '../../base/DraftEditor.react';
 import DraftModifier from '../../../model/modifier/DraftModifier';
 import keyCommandUndo from './commands/keyCommandUndo';
 
-const {hasCommandModifier, isOptionKeyCommand} = KeyBindingUtil;
+const {isOptionKeyCommand} = KeyBindingUtil;
 const isChromium =
   UserAgent.isBrowser('Chrome') || UserAgent.isBrowser('Electron');
 
@@ -175,29 +169,6 @@ export function editOnKeyDown(
 
   // If no command is specified, allow keydown event to continue.
   if (command == null || command === '') {
-    if (
-      editor.props.blockSkeleton?.enabled &&
-      keyCode === 65 &&
-      hasCommandModifier(e)
-    ) {
-      e.preventDefault();
-      const content = editorState.currentContent;
-      const firstBlock = getFirstBlock(content);
-      const lastBlock = getLastBlock(content);
-      editor.update(
-        forceSelection(
-          editorState,
-          makeSelectionState({
-            anchorKey: firstBlock.key,
-            anchorOffset: 0,
-            focusKey: lastBlock.key,
-            focusOffset: lastBlock.text.length,
-          }),
-        ),
-      );
-      return;
-    }
-
     if (keyCode === Keys.SPACE && isChromium && isOptionKeyCommand(e)) {
       // The default keydown event has already been prevented in order to stop
       // Chrome from scrolling. Insert a nbsp into the editor as OSX would for

--- a/src/component/handlers/edit/editOnKeyDown.ts
+++ b/src/component/handlers/edit/editOnKeyDown.ts
@@ -15,9 +15,15 @@ import KeyBindingUtil from '../../utils/KeyBindingUtil';
 import {DraftEditorCommand} from '../../../model/constants/DraftEditorCommand';
 import {
   EditorState,
+  forceSelection,
   pushContent,
   redo,
 } from '../../../model/immutable/EditorState';
+import {
+  getFirstBlock,
+  getLastBlock,
+} from '../../../model/immutable/ContentState';
+import {makeSelectionState} from '../../../model/immutable/SelectionState';
 import isEventHandled from '../../utils/isEventHandled';
 import keyCommandPlainDelete from './commands/keyCommandPlainDelete';
 import keyCommandDeleteWord from './commands/keyCommandDeleteWord';
@@ -33,7 +39,7 @@ import DraftEditor from '../../base/DraftEditor.react';
 import DraftModifier from '../../../model/modifier/DraftModifier';
 import keyCommandUndo from './commands/keyCommandUndo';
 
-const {isOptionKeyCommand} = KeyBindingUtil;
+const {hasCommandModifier, isOptionKeyCommand} = KeyBindingUtil;
 const isChromium =
   UserAgent.isBrowser('Chrome') || UserAgent.isBrowser('Electron');
 
@@ -169,6 +175,29 @@ export function editOnKeyDown(
 
   // If no command is specified, allow keydown event to continue.
   if (command == null || command === '') {
+    if (
+      editor.props.blockSkeleton?.enabled &&
+      keyCode === 65 &&
+      hasCommandModifier(e)
+    ) {
+      e.preventDefault();
+      const content = editorState.currentContent;
+      const firstBlock = getFirstBlock(content);
+      const lastBlock = getLastBlock(content);
+      editor.update(
+        forceSelection(
+          editorState,
+          makeSelectionState({
+            anchorKey: firstBlock.key,
+            anchorOffset: 0,
+            focusKey: lastBlock.key,
+            focusOffset: lastBlock.text.length,
+          }),
+        ),
+      );
+      return;
+    }
+
     if (keyCode === Keys.SPACE && isChromium && isOptionKeyCommand(e)) {
       // The default keydown event has already been prevented in order to stop
       // Chrome from scrolling. Insert a nbsp into the editor as OSX would for

--- a/src/component/hooks/useDraftEditorBlockSkeleton.ts
+++ b/src/component/hooks/useDraftEditorBlockSkeleton.ts
@@ -10,6 +10,7 @@ type Options = Readonly<{
   enabled: boolean;
   editorState: EditorState;
   contentsElement: HTMLElement | null;
+  onBlockSkeletonsRendered?: () => void;
   scrollContainerRef?: RefObject<HTMLElement>;
 }>;
 
@@ -77,6 +78,7 @@ export function useDraftEditorBlockSkeleton({
   enabled,
   editorState,
   contentsElement,
+  onBlockSkeletonsRendered,
   scrollContainerRef,
 }: Options): DraftEditorBlockSkeletonState | undefined {
   const [visibleBlockKeys, setVisibleBlockKeys] = useState<ReadonlySet<string>>(
@@ -199,7 +201,7 @@ export function useDraftEditorBlockSkeleton({
     };
   }, [canObserve, contentsElement, enabled, scrollContainerRef]);
 
-  return useMemo(() => {
+  const skeletonState = useMemo(() => {
     if (!enabled || !canObserve) {
       return undefined;
     }
@@ -215,4 +217,12 @@ export function useDraftEditorBlockSkeleton({
     enabled,
     visibleBlockKeys,
   ]);
+
+  useLayoutEffect(() => {
+    if (skeletonState) {
+      onBlockSkeletonsRendered?.();
+    }
+  }, [onBlockSkeletonsRendered, skeletonState]);
+
+  return skeletonState;
 }

--- a/src/component/hooks/useDraftEditorBlockSkeleton.ts
+++ b/src/component/hooks/useDraftEditorBlockSkeleton.ts
@@ -13,7 +13,7 @@ type Options = Readonly<{
   pinnedBlockKeys?: ReadonlySet<string>;
 }>;
 
-const OBSERVER_MARGIN = '1200px 0px';
+const OBSERVER_MARGIN = '500px 0px';
 
 export function useDraftEditorBlockSkeleton({
   enabled,

--- a/src/component/hooks/useDraftEditorBlockSkeleton.ts
+++ b/src/component/hooks/useDraftEditorBlockSkeleton.ts
@@ -1,4 +1,5 @@
 import {RefObject, useLayoutEffect, useMemo, useState} from 'react';
+import * as ReactDOM from 'react-dom';
 import {EditorState} from '../../model/immutable/EditorState';
 
 export type DraftEditorBlockSkeletonState = Readonly<{
@@ -20,6 +21,56 @@ function supportsNativeScrollAnchoring(): boolean {
     typeof CSS.supports !== 'function' ||
     CSS.supports('overflow-anchor: auto')
   );
+}
+
+function getBlockElements(node: Node): HTMLElement[] {
+  if (!(node instanceof Element)) {
+    return [];
+  }
+  const elements = Array.from(
+    node.querySelectorAll<HTMLElement>('[data-block-key]'),
+  );
+  if (node instanceof HTMLElement && node.matches('[data-block-key]')) {
+    elements.unshift(node);
+  }
+  return elements;
+}
+
+function getViewportSkeletonBlockKeys(
+  blockElements: readonly HTMLElement[],
+  scrollContainer: HTMLElement,
+): Set<string> {
+  const viewport = scrollContainer.getBoundingClientRect();
+  let lowerBound = 0;
+  let upperBound = blockElements.length;
+  while (lowerBound < upperBound) {
+    const midpoint = Math.floor((lowerBound + upperBound) / 2);
+    const block = blockElements[midpoint];
+    if (block && block.getBoundingClientRect().bottom <= viewport.top) {
+      lowerBound = midpoint + 1;
+    } else {
+      upperBound = midpoint;
+    }
+  }
+
+  const blockKeys = new Set<string>();
+  for (let index = lowerBound; index < blockElements.length; index += 1) {
+    const block = blockElements[index];
+    if (!block) {
+      continue;
+    }
+    const bounds = block.getBoundingClientRect();
+    if (bounds.top >= viewport.bottom) {
+      break;
+    }
+    const blockKey = block.hasAttribute('data-block-skeleton')
+      ? block.dataset.blockKey
+      : undefined;
+    if (blockKey) {
+      blockKeys.add(blockKey);
+    }
+  }
+  return blockKeys;
 }
 
 export function useDraftEditorBlockSkeleton({
@@ -71,19 +122,37 @@ export function useDraftEditorBlockSkeleton({
     };
     const observer = new IntersectionObserver(handleEntries, observerOptions);
 
-    const getBlockElements = (node: Node): Element[] => {
-      if (!(node instanceof Element)) {
-        return [];
-      }
-      const elements = Array.from(node.querySelectorAll('[data-block-key]'));
-      if (node.matches('[data-block-key]')) {
-        elements.unshift(node);
-      }
-      return elements;
-    };
-    for (const blockElement of getBlockElements(contentsElement)) {
+    let blockElements = getBlockElements(contentsElement);
+    for (const blockElement of blockElements) {
       observer.observe(blockElement);
     }
+
+    const scrollContainer = scrollContainerRef?.current ?? contentsElement;
+    const handleScroll = () => {
+      const blockKeys = getViewportSkeletonBlockKeys(
+        blockElements,
+        scrollContainer,
+      );
+      if (blockKeys.size === 0) {
+        return;
+      }
+      const updateVisibleBlockKeys = () => {
+        setVisibleBlockKeys(previousKeys => {
+          if ([...blockKeys].every(blockKey => previousKeys.has(blockKey))) {
+            return previousKeys;
+          }
+          return new Set([...previousKeys, ...blockKeys]);
+        });
+      };
+      const flush =
+        'flushSync' in ReactDOM ? ReactDOM.flushSync : undefined;
+      if (flush) {
+        flush(updateVisibleBlockKeys);
+      } else {
+        updateVisibleBlockKeys();
+      }
+    };
+    scrollContainer.addEventListener('scroll', handleScroll, {passive: true});
 
     const mutationObserver = new MutationObserver(mutations => {
       const removedKeys = new Set<string>();
@@ -112,10 +181,12 @@ export function useDraftEditorBlockSkeleton({
           return nextKeys.size === previousKeys.size ? previousKeys : nextKeys;
         });
       }
+      blockElements = getBlockElements(contentsElement);
     });
     mutationObserver.observe(contentsElement, {childList: true, subtree: true});
 
     return () => {
+      scrollContainer.removeEventListener('scroll', handleScroll);
       observer.disconnect();
       mutationObserver.disconnect();
     };

--- a/src/component/hooks/useDraftEditorBlockSkeleton.ts
+++ b/src/component/hooks/useDraftEditorBlockSkeleton.ts
@@ -155,11 +155,16 @@ export function useDraftEditorBlockSkeleton({
     scrollContainer.addEventListener('scroll', handleScroll, {passive: true});
 
     const mutationObserver = new MutationObserver(mutations => {
+      const addedKeys = new Set<string>();
       const removedKeys = new Set<string>();
       for (const mutation of mutations) {
         for (const node of mutation.addedNodes) {
           for (const blockElement of getBlockElements(node)) {
             observer.observe(blockElement);
+            const blockKey = blockElement.dataset.blockKey;
+            if (blockKey) {
+              addedKeys.add(blockKey);
+            }
           }
         }
         for (const node of mutation.removedNodes) {
@@ -176,7 +181,9 @@ export function useDraftEditorBlockSkeleton({
         setVisibleBlockKeys(previousKeys => {
           const nextKeys = new Set(previousKeys);
           for (const key of removedKeys) {
-            nextKeys.delete(key);
+            if (!addedKeys.has(key)) {
+              nextKeys.delete(key);
+            }
           }
           return nextKeys.size === previousKeys.size ? previousKeys : nextKeys;
         });

--- a/src/component/hooks/useDraftEditorBlockSkeleton.ts
+++ b/src/component/hooks/useDraftEditorBlockSkeleton.ts
@@ -10,7 +10,6 @@ type Options = Readonly<{
   editorState: EditorState;
   contentsRef: RefObject<HTMLElement>;
   scrollContainerRef: RefObject<HTMLElement>;
-  pinnedBlockKeys?: ReadonlySet<string>;
 }>;
 
 const OBSERVER_MARGIN = '500px 0px';
@@ -20,7 +19,6 @@ export function useDraftEditorBlockSkeleton({
   editorState,
   contentsRef,
   scrollContainerRef,
-  pinnedBlockKeys,
 }: Options): DraftEditorBlockSkeletonState | undefined {
   const [visibleBlockKeys, setVisibleBlockKeys] = useState<ReadonlySet<string>>(
     new Set(),
@@ -96,16 +94,12 @@ export function useDraftEditorBlockSkeleton({
     const fullBlockKeys = new Set(visibleBlockKeys);
     fullBlockKeys.add(editorState.selection.anchorKey);
     fullBlockKeys.add(editorState.selection.focusKey);
-    for (const blockKey of pinnedBlockKeys || []) {
-      fullBlockKeys.add(blockKey);
-    }
     return {fullBlockKeys};
   }, [
     canObserve,
     editorState.selection.anchorKey,
     editorState.selection.focusKey,
     enabled,
-    pinnedBlockKeys,
     visibleBlockKeys,
   ]);
 }

--- a/src/component/hooks/useDraftEditorBlockSkeleton.ts
+++ b/src/component/hooks/useDraftEditorBlockSkeleton.ts
@@ -1,4 +1,4 @@
-import {RefObject, useLayoutEffect, useMemo, useState} from 'react';
+import {RefObject, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import {EditorState} from '../../model/immutable/EditorState';
 
 export type DraftEditorBlockSkeletonState = Readonly<{
@@ -25,12 +25,14 @@ export function useDraftEditorBlockSkeleton({
   const [visibleBlockKeys, setVisibleBlockKeys] = useState<ReadonlySet<string>>(
     new Set(),
   );
+  const hasRefreshedGeometry = useRef(false);
   const blockMap = editorState.currentContent.blockMap;
   const canObserve =
     typeof window !== 'undefined' && typeof IntersectionObserver !== 'undefined';
 
   useLayoutEffect(() => {
     if (!enabled || !canObserve) {
+      hasRefreshedGeometry.current = false;
       return;
     }
 
@@ -39,35 +41,41 @@ export function useDraftEditorBlockSkeleton({
       return;
     }
 
-    const observer = new IntersectionObserver(
-      entries => {
-        setVisibleBlockKeys(previousKeys => {
-          const nextKeys = new Set(previousKeys);
-          let changed = false;
-          for (const entry of entries) {
-            const blockKey = (entry.target as HTMLElement).dataset.blockKey;
-            if (!blockKey) {
-              continue;
-            }
-            if (entry.isIntersecting) {
-              if (!nextKeys.has(blockKey)) {
-                nextKeys.add(blockKey);
-                changed = true;
-              }
-            } else if (nextKeys.delete(blockKey)) {
+    const observerOptions = {
+      root: scrollContainerRef.current,
+      rootMargin: OBSERVER_MARGIN,
+    };
+    const handleEntries: IntersectionObserverCallback = entries => {
+      setVisibleBlockKeys(previousKeys => {
+        const nextKeys = new Set(previousKeys);
+        let changed = false;
+        for (const entry of entries) {
+          const blockKey = (entry.target as HTMLElement).dataset.blockKey;
+          if (!blockKey) {
+            continue;
+          }
+          if (entry.isIntersecting) {
+            if (!nextKeys.has(blockKey)) {
+              nextKeys.add(blockKey);
               changed = true;
             }
+          } else if (nextKeys.delete(blockKey)) {
+            changed = true;
           }
-          return changed ? nextKeys : previousKeys;
-        });
-      },
-      {
-        root: scrollContainerRef.current,
-        rootMargin: OBSERVER_MARGIN,
-      },
-    );
+        }
+        return changed ? nextKeys : previousKeys;
+      });
+    };
+    const observer = new IntersectionObserver(handleEntries, observerOptions);
 
-    for (const blockElement of contents.querySelectorAll('[data-block-key]')) {
+    const blockElements = contents.querySelectorAll('[data-block-key]');
+    if (!hasRefreshedGeometry.current && visibleBlockKeys.size > 0) {
+      hasRefreshedGeometry.current = true;
+      for (const blockElement of blockElements) {
+        blockElement.getBoundingClientRect();
+      }
+    }
+    for (const blockElement of blockElements) {
       observer.observe(blockElement);
     }
     return () => observer.disconnect();
@@ -77,6 +85,7 @@ export function useDraftEditorBlockSkeleton({
     contentsRef,
     enabled,
     scrollContainerRef,
+    visibleBlockKeys,
   ]);
 
   return useMemo(() => {

--- a/src/component/hooks/useDraftEditorBlockSkeleton.ts
+++ b/src/component/hooks/useDraftEditorBlockSkeleton.ts
@@ -1,4 +1,4 @@
-import {RefObject, useLayoutEffect, useMemo, useRef, useState} from 'react';
+import {RefObject, useLayoutEffect, useMemo, useState} from 'react';
 import {EditorState} from '../../model/immutable/EditorState';
 
 export type DraftEditorBlockSkeletonState = Readonly<{
@@ -8,39 +8,44 @@ export type DraftEditorBlockSkeletonState = Readonly<{
 type Options = Readonly<{
   enabled: boolean;
   editorState: EditorState;
-  contentsRef: RefObject<HTMLElement>;
-  scrollContainerRef: RefObject<HTMLElement>;
+  contentsElement: HTMLElement | null;
+  scrollContainerRef?: RefObject<HTMLElement>;
 }>;
 
 const OBSERVER_MARGIN = '500px 0px';
 
+function supportsNativeScrollAnchoring(): boolean {
+  return (
+    typeof CSS === 'undefined' ||
+    typeof CSS.supports !== 'function' ||
+    CSS.supports('overflow-anchor: auto')
+  );
+}
+
 export function useDraftEditorBlockSkeleton({
   enabled,
   editorState,
-  contentsRef,
+  contentsElement,
   scrollContainerRef,
 }: Options): DraftEditorBlockSkeletonState | undefined {
   const [visibleBlockKeys, setVisibleBlockKeys] = useState<ReadonlySet<string>>(
     new Set(),
   );
-  const hasRefreshedGeometry = useRef(false);
-  const blockMap = editorState.currentContent.blockMap;
   const canObserve =
-    typeof window !== 'undefined' && typeof IntersectionObserver !== 'undefined';
+    typeof window !== 'undefined' &&
+    typeof IntersectionObserver !== 'undefined' &&
+    supportsNativeScrollAnchoring();
 
   useLayoutEffect(() => {
     if (!enabled || !canObserve) {
-      hasRefreshedGeometry.current = false;
       return;
     }
-
-    const contents = contentsRef.current;
-    if (!contents) {
+    if (!contentsElement) {
       return;
     }
 
     const observerOptions = {
-      root: scrollContainerRef.current,
+      root: scrollContainerRef?.current ?? contentsElement,
       rootMargin: OBSERVER_MARGIN,
     };
     const handleEntries: IntersectionObserverCallback = entries => {
@@ -66,25 +71,55 @@ export function useDraftEditorBlockSkeleton({
     };
     const observer = new IntersectionObserver(handleEntries, observerOptions);
 
-    const blockElements = contents.querySelectorAll('[data-block-key]');
-    if (!hasRefreshedGeometry.current && visibleBlockKeys.size > 0) {
-      hasRefreshedGeometry.current = true;
-      for (const blockElement of blockElements) {
-        blockElement.getBoundingClientRect();
+    const getBlockElements = (node: Node): Element[] => {
+      if (!(node instanceof Element)) {
+        return [];
       }
-    }
-    for (const blockElement of blockElements) {
+      const elements = Array.from(node.querySelectorAll('[data-block-key]'));
+      if (node.matches('[data-block-key]')) {
+        elements.unshift(node);
+      }
+      return elements;
+    };
+    for (const blockElement of getBlockElements(contentsElement)) {
       observer.observe(blockElement);
     }
-    return () => observer.disconnect();
-  }, [
-    blockMap,
-    canObserve,
-    contentsRef,
-    enabled,
-    scrollContainerRef,
-    visibleBlockKeys,
-  ]);
+
+    const mutationObserver = new MutationObserver(mutations => {
+      const removedKeys = new Set<string>();
+      for (const mutation of mutations) {
+        for (const node of mutation.addedNodes) {
+          for (const blockElement of getBlockElements(node)) {
+            observer.observe(blockElement);
+          }
+        }
+        for (const node of mutation.removedNodes) {
+          for (const blockElement of getBlockElements(node)) {
+            observer.unobserve(blockElement);
+            const blockKey = (blockElement as HTMLElement).dataset.blockKey;
+            if (blockKey) {
+              removedKeys.add(blockKey);
+            }
+          }
+        }
+      }
+      if (removedKeys.size > 0) {
+        setVisibleBlockKeys(previousKeys => {
+          const nextKeys = new Set(previousKeys);
+          for (const key of removedKeys) {
+            nextKeys.delete(key);
+          }
+          return nextKeys.size === previousKeys.size ? previousKeys : nextKeys;
+        });
+      }
+    });
+    mutationObserver.observe(contentsElement, {childList: true, subtree: true});
+
+    return () => {
+      observer.disconnect();
+      mutationObserver.disconnect();
+    };
+  }, [canObserve, contentsElement, enabled, scrollContainerRef]);
 
   return useMemo(() => {
     if (!enabled || !canObserve) {

--- a/src/component/hooks/useDraftEditorBlockSkeleton.ts
+++ b/src/component/hooks/useDraftEditorBlockSkeleton.ts
@@ -16,11 +16,13 @@ type Options = Readonly<{
 
 const OBSERVER_MARGIN = '500px 0px';
 
-function supportsNativeScrollAnchoring(): boolean {
+export function supportsBlockSkeletonRendering(): boolean {
   return (
-    typeof CSS === 'undefined' ||
-    typeof CSS.supports !== 'function' ||
-    CSS.supports('overflow-anchor: auto')
+    typeof window !== 'undefined' &&
+    typeof IntersectionObserver !== 'undefined' &&
+    (typeof CSS === 'undefined' ||
+      typeof CSS.supports !== 'function' ||
+      CSS.supports('overflow-anchor: auto'))
   );
 }
 
@@ -84,10 +86,7 @@ export function useDraftEditorBlockSkeleton({
   const [visibleBlockKeys, setVisibleBlockKeys] = useState<ReadonlySet<string>>(
     new Set(),
   );
-  const canObserve =
-    typeof window !== 'undefined' &&
-    typeof IntersectionObserver !== 'undefined' &&
-    supportsNativeScrollAnchoring();
+  const canObserve = supportsBlockSkeletonRendering();
 
   useLayoutEffect(() => {
     if (!enabled || !canObserve) {

--- a/src/component/hooks/useDraftEditorBlockSkeleton.ts
+++ b/src/component/hooks/useDraftEditorBlockSkeleton.ts
@@ -1,0 +1,102 @@
+import {RefObject, useLayoutEffect, useMemo, useState} from 'react';
+import {EditorState} from '../../model/immutable/EditorState';
+
+export type DraftEditorBlockSkeletonState = Readonly<{
+  fullBlockKeys: ReadonlySet<string>;
+}>;
+
+type Options = Readonly<{
+  enabled: boolean;
+  editorState: EditorState;
+  contentsRef: RefObject<HTMLElement>;
+  scrollContainerRef: RefObject<HTMLElement>;
+  pinnedBlockKeys?: ReadonlySet<string>;
+}>;
+
+const OBSERVER_MARGIN = '1200px 0px';
+
+export function useDraftEditorBlockSkeleton({
+  enabled,
+  editorState,
+  contentsRef,
+  scrollContainerRef,
+  pinnedBlockKeys,
+}: Options): DraftEditorBlockSkeletonState | undefined {
+  const [visibleBlockKeys, setVisibleBlockKeys] = useState<ReadonlySet<string>>(
+    new Set(),
+  );
+  const blockMap = editorState.currentContent.blockMap;
+  const canObserve =
+    typeof window !== 'undefined' && typeof IntersectionObserver !== 'undefined';
+
+  useLayoutEffect(() => {
+    if (!enabled || !canObserve) {
+      return;
+    }
+
+    const contents = contentsRef.current;
+    if (!contents) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      entries => {
+        setVisibleBlockKeys(previousKeys => {
+          const nextKeys = new Set(previousKeys);
+          let changed = false;
+          for (const entry of entries) {
+            const blockKey = (entry.target as HTMLElement).dataset.blockKey;
+            if (!blockKey) {
+              continue;
+            }
+            if (entry.isIntersecting) {
+              if (!nextKeys.has(blockKey)) {
+                nextKeys.add(blockKey);
+                changed = true;
+              }
+            } else if (nextKeys.delete(blockKey)) {
+              changed = true;
+            }
+          }
+          return changed ? nextKeys : previousKeys;
+        });
+      },
+      {
+        root: scrollContainerRef.current,
+        rootMargin: OBSERVER_MARGIN,
+      },
+    );
+
+    for (const blockElement of contents.querySelectorAll('[data-block-key]')) {
+      observer.observe(blockElement);
+    }
+    return () => observer.disconnect();
+  }, [
+    blockMap,
+    canObserve,
+    contentsRef,
+    enabled,
+    scrollContainerRef,
+  ]);
+
+  return useMemo(() => {
+    if (!enabled || !canObserve) {
+      return undefined;
+    }
+
+    const fullBlockKeys = new Set(visibleBlockKeys);
+    fullBlockKeys.add(editorState.selection.anchorKey);
+    fullBlockKeys.add(editorState.selection.focusKey);
+    for (const blockKey of pinnedBlockKeys || []) {
+      fullBlockKeys.add(blockKey);
+    }
+    return {fullBlockKeys};
+  }, [
+    canObserve,
+    editorState.selection.anchorKey,
+    editorState.selection.focusKey,
+    enabled,
+    pinnedBlockKeys,
+    visibleBlockKeys,
+  ]);
+}

--- a/src/model/decorators/DraftDecoratorType.ts
+++ b/src/model/decorators/DraftDecoratorType.ts
@@ -13,6 +13,19 @@ import {BlockNode} from '../immutable/BlockNode';
 import {ComponentType} from 'react';
 import {DraftDecoratorComponentProps} from './DraftDecorator';
 
+export type DraftDecoratorSkeletonAttributes = Readonly<
+  Record<string, string | number | boolean | undefined>
+>;
+
+export type DraftDecoratorSkeletonRange = Readonly<{
+  block: BlockNode;
+  contentState: ContentState;
+  decoratorKey: string;
+  start: number;
+  end: number;
+  entityKey: string | null;
+}>;
+
 /**
  * An interface for document decorator classes, allowing the creation of
  * custom decorator classes.
@@ -39,4 +52,11 @@ export type DraftDecoratorType = {
    * this decorated range.
    */
   getPropsForKey: (key: string) => Record<string, unknown> | null;
+  /**
+   * Return the DOM attributes that must remain available when a decorated
+   * range is rendered as part of an offscreen block skeleton.
+   */
+  getSkeletonAttributesForRange?: (
+    range: DraftDecoratorSkeletonRange,
+  ) => readonly DraftDecoratorSkeletonAttributes[] | undefined;
 };

--- a/src/model/decorators/DraftDecoratorType.ts
+++ b/src/model/decorators/DraftDecoratorType.ts
@@ -13,11 +13,7 @@ import {BlockNode} from '../immutable/BlockNode';
 import {ComponentType} from 'react';
 import {DraftDecoratorComponentProps} from './DraftDecorator';
 
-export type DraftDecoratorSkeletonAttributes = Readonly<
-  Record<string, string | number | boolean | undefined>
->;
-
-export type DraftDecoratorSkeletonRange = Readonly<{
+export type DraftDecoratorDOMAnchorRange = Readonly<{
   block: BlockNode;
   contentState: ContentState;
   decoratorKey: string;
@@ -50,13 +46,12 @@ export type DraftDecoratorType = {
   /**
    * Given a decorator key, optionally return the props to use when rendering
    * this decorated range.
-   */
+  */
   getPropsForKey: (key: string) => Record<string, unknown> | null;
   /**
-   * Return the DOM attributes that must remain available when a decorated
-   * range is rendered as part of an offscreen block skeleton.
+   * Return stable DOM ids that Draft renders around this decorated range.
    */
-  getSkeletonAttributesForRange?: (
-    range: DraftDecoratorSkeletonRange,
-  ) => readonly DraftDecoratorSkeletonAttributes[] | undefined;
+  getDOMAnchorIdsForRange?: (
+    range: DraftDecoratorDOMAnchorRange,
+  ) => readonly string[] | undefined;
 };


### PR DESCRIPTION
## Summary

This adds an Editor-owned skeleton mode for large documents. Offscreen blocks keep a lightweight, editable text subtree while skipping block renderers, decorator components, and leaf components; selected and near-viewport blocks use the normal renderer.

Visibility uses one `IntersectionObserver` with 500 px overscan, while structural edits are registered without a render-all measurement frame. Native scroll anchoring preserves position during promotion. Decorators can expose stable DOM IDs for addressable cards and markers, and skeleton text remains content-editable so native selection and editing continue to work without pinned blocks or keyboard special cases.

Draft now reports skeleton-state DOM commits through `onBlockSkeletonsRendered`. Consumers can refresh application-owned geometry after promotion without maintaining a parallel visibility signal. Draft does not inspect or rewrite application `content-visibility` styles, keeping those optimizations independent.

- [x] I used AI

## Decisions

- The callback fires from a layout effect after the promoted DOM commits, so geometry consumers observe the current tree.
- Unsupported `IntersectionObserver` or native scroll anchoring falls back to full rendering.

## Test Plan

- Full suite: 44 suites passed; 402 tests passed, 3 skipped; 500 snapshots passed.
- Latest callback change: lint passed; the 13 focused editor tests passed; the library build exited successfully.
- Downstream production-mode coverage verifies select-all, distant caret promotion, autoscroll, typing, marker navigation, and timeline seek behavior. The latest downstream integration passed formatting, lint, typecheck, and 3 focused unit tests; its focused UI files could not be rerun because no UI-test server was detectable.

Published as `@descript/draft-js@0.11.6-descript.38` for [descriptinc/descript#38103](https://github.com/descriptinc/descript/pull/38103).
